### PR TITLE
Implement basic socrata ingestion

### DIFF
--- a/airflow/dags/check_socrata_table_freshness.py
+++ b/airflow/dags/check_socrata_table_freshness.py
@@ -1,16 +1,19 @@
 import datetime as dt
 import logging
+from pathlib import Path
 from typing import Tuple
+from urllib.request import urlretrieve
 
-from airflow.decorators import dag, task
+from airflow.decorators import dag, task, task_group
 from airflow.operators.empty import EmptyOperator
 
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.utils.trigger_rule import TriggerRule
 import pandas as pd
+import geopandas as gpd
 
-from utils.db import get_pg_engine
+from utils.db import get_pg_engine, get_data_table_names_in_schema
 from utils.socrata import SocrataTable, SocrataTableMetadata
 
 task_logger = logging.getLogger("airflow.task")
@@ -27,6 +30,8 @@ chicago_cta_stations_table = SocrataTable(table_id="8pix-ypme", table_name="chic
     tags=["metadata"],
 )
 def check_table_freshness():
+    end_1 = EmptyOperator(task_id="end", trigger_rule=TriggerRule.ALL_DONE)
+
     @task
     def get_socrata_table_metadata(socrata_table: SocrataTable) -> SocrataTableMetadata:
         socrata_metadata = SocrataTableMetadata(socrata_table=socrata_table)
@@ -41,29 +46,124 @@ def check_table_freshness():
         socrata_metadata: SocrataTableMetadata, conn_id: str
     ) -> pd.DataFrame:
         engine = get_pg_engine(conn_id=conn_id)
-        socrata_metadata.check_table_metadata(engine=engine)
+        socrata_metadata.check_warehouse_data_freshness(engine=engine)
         task_logger.info(
             f"Extracted table freshness information.",
-            f"Fresh source data available: {socrata_metadata.table_check_metadata['updated_data_available']}",
-            f"Fresh source metadata available: {socrata_metadata.table_check_metadata['updated_metadata_available']}",
+            f"Fresh source data available: {socrata_metadata.data_freshness_check['updated_data_available']}",
+            f"Fresh source metadata available: {socrata_metadata.data_freshness_check['updated_metadata_available']}",
         )
         return socrata_metadata
 
     @task
-    def ingest_table_freshness_check_metadata(socrata_metadata: SocrataTableMetadata, conn_id: str):
+    def ingest_table_freshness_check_metadata(
+        socrata_metadata: SocrataTableMetadata, conn_id: str
+    ) -> None:
         engine = get_pg_engine(conn_id=conn_id)
-        insertable_record_df = socrata_metadata.get_insertable_check_table_metadata_record(
-            engine=engine, output_type="DataFrame"
-        )
-        task_logger.info(f"type(insertable_record_df): {type(insertable_record_df)}")
-        insertable_record_df.to_sql(
-            name="table_metadata",
-            schema="metadata",
-            con=engine,
-            if_exists="append",
-        )
+        socrata_metadata.insert_current_freshness_check_to_db(engine=engine)
         task_logger.info(
-            f"Ingested table freshness check results into metadata table. Record: {insertable_record_df}"
+            f"Ingested table freshness check results into metadata table.  ",
+            f"Freshness check id: {socrata_metadata.freshness_check_id}",
+        )
+
+    @task.branch(trigger_rule=TriggerRule.ALL_DONE)
+    def fresher_source_data_available(
+        socrata_metadata: SocrataTableMetadata,
+    ) -> str:
+        if socrata_metadata.data_freshness_check["updated_data_available"]:
+            task_logger.info(f"Fresh data available, entering extract-load branch")
+            return "extract_load_task_group"
+        else:
+            return "end"
+
+    @task_group
+    def extract_load_task_group(socrata_metadata: SocrataTableMetadata, conn_id: str) -> None:
+        def get_local_file_path(socrata_metadata: SocrataTableMetadata) -> Path:
+            output_dir = Path("data_raw").resolve()
+            output_dir.mkdir(exist_ok=True)
+            local_file_path = output_dir.joinpath(socrata_metadata.format_file_name())
+            return local_file_path
+
+        @task
+        def download_fresh_data(socrata_metadata: SocrataTableMetadata) -> None:
+            output_file_path = get_local_file_path(socrata_metadata=socrata_metadata)
+            urlretrieve(url=socrata_metadata.get_data_download_url(), filename=output_file_path)
+
+        @task.branch(trigger_rule=TriggerRule.ALL_DONE)
+        def table_exists_in_warehouse(
+            socrata_metadata: SocrataTableMetadata,
+            conn_id: str,
+        ) -> str:
+            tables_in_data_raw_schema = get_data_table_names_in_schema(
+                engine=get_pg_engine(conn_id=conn_id), schema_name="data_raw"
+            )
+            if socrata_metadata.table_name not in tables_in_data_raw_schema:
+                return "ingest_straight_into_table_in_data_raw"
+            else:
+                return "ingest_into_temporary_table"
+
+        @task
+        def ingest_straight_into_table_in_data_raw(
+            socrata_metadata: SocrataTableMetadata, conn_id: str
+        ) -> None:
+            local_file_path = get_local_file_path(socrata_metadata=socrata_metadata)
+            if socrata_metadata.is_geospatial:
+                gdf = gpd.read_file(local_file_path)
+                gdf.to_postgis(
+                    name=socrata_metadata.table_name,
+                    schema="data_raw",
+                    con=get_pg_engine(conn_id=conn_id),
+                )
+            else:
+                df = pd.read_csv(local_file_path)
+                df.to_sql(
+                    name=socrata_metadata.table_name,
+                    schema="data_raw",
+                    con=get_pg_engine(conn_id=conn_id),
+                )
+
+        @task
+        def ingest_into_temporary_table(
+            socrata_metadata: SocrataTableMetadata, conn_id: str
+        ) -> None:
+            local_file_path = get_local_file_path(socrata_metadata=socrata_metadata)
+            if socrata_metadata.is_geospatial:
+                gdf = gpd.read_file(local_file_path)
+                gdf["ingestion_check_time"] = socrata_metadata.time_of_check
+                gdf.to_postgis(
+                    name=f"temp_{socrata_metadata.table_name}",
+                    schema="data_raw",
+                    con=get_pg_engine(conn_id=conn_id),
+                )
+            else:
+                df = pd.read_csv(local_file_path)
+                df["ingestion_check_time"] = socrata_metadata.time_of_check
+                df.to_sql(
+                    name=f"temp_{socrata_metadata.table_name}",
+                    schema="data_raw",
+                    con=get_pg_engine(conn_id=conn_id),
+                )
+
+        socrata_metadata_1 = download_fresh_data(socrata_metadata=socrata_metadata)
+        table_exists_1 = table_exists_in_warehouse(
+            socrata_metadata=socrata_metadata_1, conn_id=conn_id
+        )
+        ingest_into_data_raw_table_1 = ingest_straight_into_table_in_data_raw(
+            socrata_metadata=socrata_metadata_1, conn_id=conn_id
+        )
+        ingest_into_temporary_table_1 = ingest_into_temporary_table(
+            socrata_metadata=socrata_metadata_1, conn_id=conn_id
+        )
+
+        ingest_new_records_to_raw_1 = EmptyOperator(
+            task_id="ingest_new_records_to_raw", trigger_rule=TriggerRule.ALL_DONE
+        )
+
+        socrata_metadata_1 >> table_exists_1 >> ingest_into_data_raw_table_1
+        (
+            socrata_metadata_1
+            >> table_exists_1
+            >> ingest_into_temporary_table_1
+            >> ingest_new_records_to_raw_1
         )
 
     socrata_table_metadata_1 = get_socrata_table_metadata(socrata_table=chicago_cta_stations_table)
@@ -73,8 +173,32 @@ def check_table_freshness():
     ingest_freshness_metadata_1 = ingest_table_freshness_check_metadata(
         socrata_metadata=socrata_table_metadata_2, conn_id=POSTGRES_CONN_ID
     )
+    fresh_source_data_available_1 = fresher_source_data_available(
+        socrata_metadata=socrata_table_metadata_2
+    )
+    extract_load_task_group_1 = extract_load_task_group(
+        socrata_metadata=socrata_table_metadata_2, conn_id=POSTGRES_CONN_ID
+    )
 
-    (socrata_table_metadata_1 >> socrata_table_metadata_2 >> ingest_freshness_metadata_1)
+    update_freshness_check_in_db_1 = EmptyOperator(
+        task_id="update_freshness_check_in_db", trigger_rule=TriggerRule.ALL_DONE
+    )
+
+    (
+        socrata_table_metadata_1
+        >> socrata_table_metadata_2
+        >> ingest_freshness_metadata_1
+        >> fresh_source_data_available_1
+        >> end_1
+    )
+    (
+        socrata_table_metadata_1
+        >> socrata_table_metadata_2
+        >> ingest_freshness_metadata_1
+        >> fresh_source_data_available_1
+        >> extract_load_task_group_1
+        >> update_freshness_check_in_db_1
+    )
 
 
 check_table_freshness_dag = check_table_freshness()

--- a/airflow/dags/ensure_data_raw_schema_exists.py
+++ b/airflow/dags/ensure_data_raw_schema_exists.py
@@ -1,0 +1,65 @@
+import datetime as dt
+import logging
+
+from airflow.decorators import dag, task
+from airflow.operators.empty import EmptyOperator
+from airflow.utils.trigger_rule import TriggerRule
+
+from utils.db import (
+    get_pg_engine,
+    database_has_schema,
+    execute_structural_command,
+)
+
+
+task_logger = logging.getLogger("airflow.task")
+
+POSTGRES_CONN_ID = "dwh_db_conn"
+SCHEMA_NAME = "data_raw"
+
+
+@dag(
+    schedule=None,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["metadata"],
+)
+def ensure_data_raw_schema_exists():
+    @task.branch(trigger_rule=TriggerRule.ALL_DONE)
+    def schema_exists(conn_id: str, schema_name: str) -> str:
+        if not database_has_schema(engine=get_pg_engine(conn_id=conn_id), schema_name=schema_name):
+            task_logger.info(
+                f"Schema '{schema_name}' not in database. Branching to create_schema task."
+            )
+            return "create_schema"
+        else:
+            task_logger.info(f"Schema '{schema_name}' in database. Ending DAG.")
+            return "end"
+
+    @task(trigger_rule=TriggerRule.ALL_DONE)
+    def create_schema(conn_id: str, schema_name: str) -> None:
+        task_logger.info(f"Creating '{schema_name}' schema")
+        engine = get_pg_engine(conn_id=conn_id)
+        try:
+            username = engine.url.username
+            execute_structural_command(
+                query=f"""
+                CREATE SCHEMA {schema_name};
+                GRANT USAGE ON SCHEMA metadata TO {username};
+                GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA {schema_name} TO {username};
+                ALTER DEFAULT PRIVILEGES FOR USER {username} IN SCHEMA {schema_name}
+                    GRANT ALL ON TABLES TO {username};
+                """,
+                engine=engine,
+            )
+        except Exception as e:
+            print(f"Failed to create '{schema_name}' schema. Error: {e}, {type(e)}")
+
+    schema_exists_1 = schema_exists(conn_id=POSTGRES_CONN_ID, schema_name=SCHEMA_NAME)
+    create_schema_1 = create_schema(conn_id=POSTGRES_CONN_ID, schema_name=SCHEMA_NAME)
+    end_1 = EmptyOperator(task_id="end", trigger_rule=TriggerRule.ALL_DONE)
+
+    schema_exists_1 >> [create_schema_1, end_1]
+
+
+check_metadata_schema_dag = ensure_data_raw_schema_exists()

--- a/airflow/dags/update_socrata_data_table.py
+++ b/airflow/dags/update_socrata_data_table.py
@@ -1,0 +1,179 @@
+import datetime as dt
+import logging
+from pathlib import Path
+from typing import Tuple
+from urllib.request import urlretrieve
+
+from airflow.decorators import dag, task, task_group
+from airflow.operators.empty import EmptyOperator
+from airflow.utils.trigger_rule import TriggerRule
+from airflow.utils.edgemodifier import Label
+import pandas as pd
+import geopandas as gpd
+
+from utils.db import get_pg_engine, get_data_table_names_in_schema
+from utils.socrata import SocrataTable, SocrataTableMetadata
+
+task_logger = logging.getLogger("airflow.task")
+
+POSTGRES_CONN_ID = "dwh_db_conn"
+
+chicago_cta_stations_table = SocrataTable(table_id="8pix-ypme", table_name="chicago_cta_stations")
+
+
+def get_local_file_path(socrata_metadata: SocrataTableMetadata) -> Path:
+    output_dir = Path("data_raw").resolve()
+    output_dir.mkdir(exist_ok=True)
+    local_file_path = output_dir.joinpath(socrata_metadata.format_file_name())
+    return local_file_path
+
+
+def ingest_into_table(
+    socrata_metadata: SocrataTableMetadata, conn_id: str, temp_table: bool = False
+) -> None:
+    local_file_path = get_local_file_path(socrata_metadata=socrata_metadata)
+
+    if temp_table:
+        table_name = f"temp_{socrata_metadata.table_name}"
+        if_exists = "replace"
+    else:
+        table_name = f"temp_{socrata_metadata.table_name}"
+        if_exists = "fail"
+    task_logger.info(f"Ingesting data to database table 'data_raw.{table_name}'")
+    time_of_check = socrata_metadata.data_freshness_check["time_of_check"]
+    engine = get_pg_engine(conn_id=conn_id)
+    if socrata_metadata.is_geospatial:
+        gdf = gpd.read_file(local_file_path)
+        gdf["ingestion_check_time"] = time_of_check
+        gdf.to_postgis(
+            name=table_name,
+            schema="data_raw",
+            con=engine,
+            if_exists=if_exists,
+        )
+        task_logger.info("Successfully ingested data using gpd.to_postgis()")
+    else:
+        df = pd.read_csv(local_file_path)
+        df["ingestion_check_time"] = time_of_check
+        df.to_sql(
+            name=table_name,
+            schema="data_raw",
+            con=engine,
+            if_exists=if_exists,
+        )
+        task_logger.info("Successfully ingested data using pd.to_sql()")
+
+
+@task
+def get_socrata_table_metadata(socrata_table: SocrataTable) -> SocrataTableMetadata:
+    socrata_metadata = SocrataTableMetadata(socrata_table=socrata_table)
+    task_logger.info(
+        f"Retrieved metadata for socrata table {socrata_metadata.table_name} and table_id",
+        f" {socrata_metadata.table_id}.",
+    )
+    return socrata_metadata
+
+
+@task
+def extract_table_freshness_info(
+    socrata_metadata: SocrataTableMetadata, conn_id: str
+) -> pd.DataFrame:
+    engine = get_pg_engine(conn_id=conn_id)
+    socrata_metadata.check_warehouse_data_freshness(engine=engine)
+    task_logger.info(
+        f"Extracted table freshness information.",
+        f"Fresh source data available: {socrata_metadata.data_freshness_check['updated_data_available']}",
+        f"Fresh source metadata available: {socrata_metadata.data_freshness_check['updated_metadata_available']}",
+    )
+    return socrata_metadata
+
+
+@task
+def ingest_table_freshness_check_metadata(
+    socrata_metadata: SocrataTableMetadata, conn_id: str
+) -> None:
+    engine = get_pg_engine(conn_id=conn_id)
+    socrata_metadata.insert_current_freshness_check_to_db(engine=engine)
+    task_logger.info(
+        f"Ingested table freshness check results into metadata table.  ",
+        f"Freshness check id: {socrata_metadata.freshness_check_id}",
+    )
+    return socrata_metadata
+
+
+@task.branch(trigger_rule=TriggerRule.NONE_FAILED)
+def fresher_source_data_available(socrata_metadata: SocrataTableMetadata, **kwargs) -> str:
+    task_logger.info(f"In fresher_source_data_available, here's what kwargs looks like {kwargs}")
+    if socrata_metadata.data_freshness_check["updated_data_available"]:
+        task_logger.info(f"Fresh data available, entering extract-load branch")
+        return "extract_load_task_group.download_fresh_data"
+    else:
+        return "end"
+
+
+@task
+def download_fresh_data(**kwargs) -> SocrataTableMetadata:
+    ti = kwargs["ti"]
+    socrata_metadata = ti.xcom_pull(task_ids="ingest_table_freshness_check_metadata")
+    output_file_path = get_local_file_path(socrata_metadata=socrata_metadata)
+    urlretrieve(url=socrata_metadata.get_data_download_url(), filename=output_file_path)
+    return socrata_metadata
+
+
+@task.branch(trigger_rule=TriggerRule.NONE_FAILED)
+def table_exists_in_warehouse(socrata_metadata: SocrataTableMetadata, conn_id: str) -> str:
+    tables_in_data_raw_schema = get_data_table_names_in_schema(
+        engine=get_pg_engine(conn_id=conn_id), schema_name="data_raw"
+    )
+    if socrata_metadata.table_name not in tables_in_data_raw_schema:
+        return "extract_load_task_group.ingest_into_new_table_in_data_raw"
+    else:
+        return "extract_load_task_group.ingest_into_temporary_table"
+
+
+@task
+def ingest_into_new_table_in_data_raw(conn_id: str, **kwargs) -> SocrataTableMetadata:
+    ti = kwargs["ti"]
+    socrata_metadata = ti.xcom_pull(task_ids="extract_load_task_group.download_fresh_data")
+    ingest_into_table(socrata_metadata=socrata_metadata, conn_id=conn_id, temp_table=False)
+    return socrata_metadata
+
+
+@task
+def ingest_into_temporary_table(conn_id: str, **kwargs) -> SocrataTableMetadata:
+    ti = kwargs["ti"]
+    socrata_metadata = ti.xcom_pull(task_ids="extract_load_task_group.download_fresh_data")
+    ingest_into_table(socrata_metadata=socrata_metadata, conn_id=conn_id, temp_table=True)
+    return socrata_metadata
+
+
+@dag(
+    schedule=None,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["metadata"],
+)
+def update_socrata_data_table():
+    end_1 = EmptyOperator(task_id="end", trigger_rule=TriggerRule.NONE_FAILED)
+
+    @task_group
+    def extract_load_task_group(conn_id: str) -> None:
+        task_logger.info(f"In extract_load_task_group")
+        metadata_4 = download_fresh_data()
+        table_exists_1 = table_exists_in_warehouse(socrata_metadata=metadata_4, conn_id=conn_id)
+        ingest_to_new_1 = ingest_into_new_table_in_data_raw(conn_id=conn_id)
+        ingest_to_temp_1 = ingest_into_new_table_in_data_raw(conn_id=conn_id)
+
+        metadata_4 >> table_exists_1 >> Label("Adding Table") >> ingest_to_new_1
+        metadata_4 >> table_exists_1 >> Label("Updating Table") >> ingest_to_temp_1
+
+    metadata_1 = get_socrata_table_metadata(socrata_table=chicago_cta_stations_table)
+    metadata_2 = extract_table_freshness_info(metadata_1, POSTGRES_CONN_ID)
+    metadata_3 = ingest_table_freshness_check_metadata(metadata_2, POSTGRES_CONN_ID)
+    fresh_source_data_available_1 = fresher_source_data_available(socrata_metadata=metadata_3)
+    extract_load_task_group_1 = extract_load_task_group(POSTGRES_CONN_ID)
+
+    fresh_source_data_available_1 >> [extract_load_task_group_1, end_1]
+
+
+check_table_freshness_dag = update_socrata_data_table()

--- a/airflow/dags/utils/db.py
+++ b/airflow/dags/utils/db.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from geoalchemy2 import Geometry, Geography  # Necessary for reflection of cols with spatial dtypes
@@ -10,6 +10,7 @@ from sqlalchemy.exc import NoSuchTableError
 from sqlalchemy.orm import Session
 from sqlalchemy.schema import CreateSchema, MetaData, Table
 from sqlalchemy.sql.selectable import Select
+from sqlalchemy.sql.dml import Insert, Update
 
 
 def get_pg_engine(conn_id: str) -> Engine:
@@ -92,5 +93,14 @@ def execute_result_returning_orm_query(
                 query_result = session.execute(select_query).fetchmany(size=limit_n)
             session.commit()
         return pd.DataFrame(query_result)
+    except Exception as err:
+        print(f"Couldn't execute the given ORM-style query: {err}, type: {type(err)}")
+
+
+def execute_dml_orm_query(engine: Engine, dml_stmt: Union[Insert, Update]) -> None:
+    try:
+        with Session(engine) as session:
+            session.execute(dml_stmt)
+            session.commit()
     except Exception as err:
         print(f"Couldn't execute the given ORM-style query: {err}, type: {type(err)}")

--- a/airflow/dags/utils/db.py
+++ b/airflow/dags/utils/db.py
@@ -90,6 +90,7 @@ def execute_result_returning_orm_query(
                 query_result = session.execute(select_query).all()
             else:
                 query_result = session.execute(select_query).fetchmany(size=limit_n)
+            session.commit()
         return pd.DataFrame(query_result)
     except Exception as err:
         print(f"Couldn't execute the given ORM-style query: {err}, type: {type(err)}")

--- a/airflow/dags/utils/socrata.py
+++ b/airflow/dags/utils/socrata.py
@@ -337,7 +337,9 @@ class SocrataTableMetadata:
             insert_statement = (
                 insert(metadata_table).values(self.data_freshness_check).returning(metadata_table)
             )
-            result_df = execute_result_returning_query(engine=engine, query=insert_statement)
+            result_df = execute_result_returning_orm_query(
+                engine=engine, select_query=insert_statement
+            )
             if len(result_df) != 1:
                 raise Exception("There should only be one result returned for this freshness check")
             self.freshness_check_id = result_df["id"].max()

--- a/airflow/dags/utils/socrata.py
+++ b/airflow/dags/utils/socrata.py
@@ -17,6 +17,7 @@ from .db import (
     get_reflected_db_table,
     execute_result_returning_orm_query,
 )
+from .utils import typeset_zulu_tz_datetime_str
 
 # for interactive dev work
 # from db import (
@@ -24,6 +25,7 @@ from .db import (
 #     get_reflected_db_table,
 #     execute_result_returning_orm_query,
 # )
+# from utils import typeset_zulu_tz_datetime_str
 
 
 @dataclass
@@ -49,7 +51,7 @@ class SocrataTableMetadata:
         self.download_format = self.validate_download_format(
             download_format=socrata_table.download_format
         )
-        self.table_check_metadata = self.get_initial_table_check_metadata()
+        self.data_freshness_check = self.initialize_data_freshness_check_record()
         self.freshness_check_id = None
 
     def get_table_metadata(self) -> Dict:
@@ -259,7 +261,7 @@ class SocrataTableMetadata:
         )
         return results_df
 
-    def get_initial_table_check_metadata(self) -> None:
+    def initialize_data_freshness_check_record(self) -> None:
         """There's probably a better name for this idea than 'table_check_metadata'. The goal
         is to see if fresh data is available, log the results of that freshness-check in the dwh,
         and then triger data refreshing if appropriate."""
@@ -278,55 +280,62 @@ class SocrataTableMetadata:
             "metadata_json": self.metadata,
         }
 
-    def check_table_metadata(self, engine: Engine):
+    def check_warehouse_data_freshness(self, engine: Engine):
         check_df = self.get_prior_metadata_checks_from_db(engine=engine)
-        self.table_check_metadata["updated_data_available"] = False
-        self.table_check_metadata["updated_metadata_available"] = False
-        if len(check_df) == 0:
-            self.table_check_metadata["updated_data_available"] = True
-            self.table_check_metadata["updated_metadata_available"] = True
+        self.data_freshness_check["updated_data_available"] = False
+        self.data_freshness_check["updated_metadata_available"] = False
+        data_pulled_previously_mask = check_df["data_pulled_this_check"] == True
+        if (len(check_df) == 0) or (data_pulled_previously_mask.sum() == 0):
+            self.data_freshness_check["updated_data_available"] = True
+            self.data_freshness_check["updated_metadata_available"] = True
         else:
-            data_pull_mask = check_df["data_pulled_this_check"] == True
-            latest_pull = check_df.loc[data_pull_mask, "time_of_check"].max()
-            latest_source_data_update = self.get_latest_data_update_datetime()
-            latest_source_metadata_update = self.get_latest_metadata_update_datetime()
+            latest_pull = check_df.loc[data_pulled_previously_mask, "time_of_check"].max()
+            latest_source_data_update = typeset_zulu_tz_datetime_str(
+                datetime_str=self.get_latest_data_update_datetime()
+            )
+            latest_source_metadata_update = typeset_zulu_tz_datetime_str(
+                datetime_str=self.get_latest_metadata_update_datetime()
+            )
             if latest_source_data_update > latest_pull:
-                self.table_check_metadata["updated_data_available"] = True
+                self.data_freshness_check["updated_data_available"] = True
             if latest_source_metadata_update > latest_pull:
-                self.table_check_metadata["updated_metadata_available"] = True
+                self.data_freshness_check["updated_metadata_available"] = True
             if (latest_pull >= latest_source_data_update) & (
                 latest_pull >= latest_source_metadata_update
             ):
-                self.table_check_metadata["data_pulled_this_check"] = False
+                self.data_freshness_check["data_pulled_this_check"] = False
 
     def get_this_tables_prior_freshness_checks_from_db(self, engine: Engine) -> pd.DataFrame:
         table_metadata_obj = get_reflected_db_table(
             engine=engine, table_name="table_metadata", schema_name="metadata"
         )
         select_query = select(table_metadata_obj).where(
-            table_metadata_obj.c.table_id == self.table_check_metadata["table_id"]
+            table_metadata_obj.c.table_id == self.data_freshness_check["table_id"]
         )
         return execute_result_returning_orm_query(engine=engine, select_query=select_query)
 
     def get_current_freshness_check_metadata_from_db(self, engine: Engine) -> pd.DataFrame:
-        if self.table_check_metadata["updated_data_available"] is None:
-            self.check_table_metadata(engine=engine)
+        if self.data_freshness_check["updated_data_available"] is None:
+            self.check_warehouse_data_freshness(engine=engine)
         prior_freshness_check_df = self.get_this_table_ids_prior_freshness_checks_from_db(
             engine=engine
         )
         return prior_freshness_check_df.loc[
-            prior_freshness_check_df["time_of_check"] == self.table_check_metadata["time_of_check"]
+            prior_freshness_check_df["time_of_check"] == self.data_freshness_check["time_of_check"]
         ].reset_index(drop=True)
 
+    def format_file_name(self) -> str:
+        return f"{self.table_id}_{self.time_of_check}.{self.download_format}"
+
     def insert_current_freshness_check_to_db(self, engine: Engine) -> None:
-        if self.table_check_metadata["updated_data_available"] is None:
-            self.check_table_metadata(engine=engine)
+        if self.data_freshness_check["updated_data_available"] is None:
+            self.check_warehouse_data_freshness(engine=engine)
         metadata_table = get_reflected_db_table(
             engine=engine, table_name="table_metadata", schema_name="metadata"
         )
         if self.freshness_check_id is None:
             insert_statement = (
-                insert(metadata_table).values(self.table_check_metadata).returning(metadata_table)
+                insert(metadata_table).values(self.data_freshness_check).returning(metadata_table)
             )
             result_df = execute_result_returning_query(engine=engine, query=insert_statement)
             if len(result_df) != 1:

--- a/airflow/dags/utils/socrata.py
+++ b/airflow/dags/utils/socrata.py
@@ -325,7 +325,7 @@ class SocrataTableMetadata:
         ].reset_index(drop=True)
 
     def format_file_name(self) -> str:
-        return f"{self.table_id}_{self.time_of_check}.{self.download_format}"
+        return f"{self.table_id}_{self.metadata['time_of_collection']}.{self.download_format}"
 
     def insert_current_freshness_check_to_db(self, engine: Engine) -> None:
         if self.data_freshness_check["updated_data_available"] is None:

--- a/airflow/dags/utils/utils.py
+++ b/airflow/dags/utils/utils.py
@@ -1,0 +1,8 @@
+import datetime as dt
+import re
+
+
+def typeset_zulu_tz_datetime_str(datetime_str: str) -> dt.datetime:
+    datetime_str = re.sub("Z$", " +0000", datetime_str)
+    datetime_dt = dt.datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%S %z")
+    return datetime_dt


### PR DESCRIPTION
Current DAG (with utils) implementation successfully checks Socrata's table metadata api, determines how recently the source data was updated, downloads it if it's fresher than the freshest data (of that table) in the data warehouse, and ingests that downloaded data either into a newly created table in `data_raw`, or into a "temporary" table in `data_raw` to subsequently undergo further checks (eg "are the columns consistent with the current table?") before distinct records are ingested into `data_raw`.