### PR TITLE
Simplify socrata table metadata init

### DIFF
--- a/airflow/dags/cc_utils/socrata.py
+++ b/airflow/dags/cc_utils/socrata.py
@@ -38,7 +38,6 @@ class SocrataTableMetadata:
         self.socrata_table = socrata_table
         self.table_id = self.socrata_table.table_id
         self.metadata = self.get_table_metadata()
-        self.has_geospatial_feature = self.table_has_geospatial_feature()
         self.data_freshness_check = self.initialize_data_freshness_check_record()
         self.freshness_check_id = None
 
@@ -113,6 +112,7 @@ class SocrataTableMetadata:
                 }
         return {}
 
+    @property
     def table_has_geospatial_feature(self) -> bool:
         socrata_geo_datatypes = [
             "Line",
@@ -157,7 +157,7 @@ class SocrataTableMetadata:
         return (
             (not self.table_has_data_columns)
             and (self.table_has_geo_type_view or self.table_has_map_type_display)
-        ) or (self.has_geospatial_feature)
+        ) or (self.table_has_geospatial_feature)
 
     def get_valid_download_formats(self) -> Dict:
         valid_download_formats = {

--- a/airflow/dags/cc_utils/socrata.py
+++ b/airflow/dags/cc_utils/socrata.py
@@ -35,17 +35,10 @@ class SocrataTableMetadata:
         self,
         socrata_table: SocrataTable,
     ):
-        self.table_id = socrata_table.table_id
+        self.socrata_table = socrata_table
+        self.table_id = self.socrata_table.table_id
         self.metadata = self.get_table_metadata()
-        self.table_name = self.validate_table_name(table_name=socrata_table.table_name)
-        self.resource_metadata = self.get_resource_metadata()
-        self.column_details = self.get_column_details()
         self.has_geospatial_feature = self.table_has_geospatial_feature()
-        self.data_domain = self.get_data_domain()
-        self.is_geospatial = self.is_geospatial_table()
-        self.download_format = self.validate_download_format(
-            download_format=socrata_table.download_format
-        )
         self.data_freshness_check = self.initialize_data_freshness_check_record()
         self.freshness_check_id = None
 
@@ -76,19 +69,22 @@ class SocrataTableMetadata:
             print("Did you mean to enter attr_dict['resource']")
             raise
 
-    def get_resource_metadata(self):
+    @property
+    def resource_metadata(self):
         return self.get_table_metadata_attr(attr_dict=self.metadata, attr_name="resource")
 
-    def validate_table_name(self, table_name: Optional[str]) -> str:
-        if table_name is None:
+    @property
+    def table_name(self) -> str:
+        if self.socrata_table.table_name is None:
             table_name = self.get_table_metadata_attr(
                 a_dict=self.resource_metadata, attr_name="name"
             )
             return "_".join(re.sub("[^0-9a-zA-Z]+", "", table_name.lower()).split())
         else:
-            return table_name
+            return self.socrata_table.table_name
 
-    def get_data_domain(self) -> str:
+    @property
+    def data_domain(self) -> str:
         metadatas_metadata = self.get_table_metadata_attr(
             attr_dict=self.metadata, attr_name="metadata"
         )
@@ -98,7 +94,8 @@ class SocrataTableMetadata:
         with open(file_path, "w", encoding="utf-8") as json_file:
             json.dump(self.metadata, json_file, ensure_ascii=False, indent=4, default=str)
 
-    def get_column_details(self) -> Dict:
+    @property
+    def column_details(self) -> Dict:
         if self.resource_metadata is not None:
             column_metadata_fields = [
                 "columns_name",
@@ -152,7 +149,8 @@ class SocrataTableMetadata:
         )
         return len(table_data_cols) != 0
 
-    def is_geospatial_table(self) -> bool:
+    @property
+    def is_geospatial(self) -> bool:
         return (
             (not self.table_has_data_columns())
             and (self.table_has_geo_type_view() or self.table_has_map_type_display())
@@ -185,14 +183,15 @@ class SocrataTableMetadata:
                 f"Download format '{download_format}' isn't supported. Pick from {all_pairs}"
             )
 
-    def validate_download_format(self, download_format: str = None) -> str:
-        if download_format is None:
+    @property
+    def download_format(self) -> str:
+        if self.socrata_table.download_format is None:
             if self.is_geospatial:
                 return "GeoJSON"
             else:
                 return "csv"
         else:
-            download_format = download_format.lower()
+            download_format = self.socrata_table.download_format.lower()
             self.assert_download_format_is_supported(download_format=download_format)
             valid_download_formats = self.get_valid_download_formats()
             if download_format in valid_download_formats.values():
@@ -202,7 +201,8 @@ class SocrataTableMetadata:
             else:
                 raise Exception("Very invalid download format (should have already been caught)")
 
-    def get_data_download_url(self) -> str:
+    @property
+    def data_download_url(self) -> str:
         if self.is_geospatial:
             return f"https://{self.data_domain}/api/geospatial/{self.table_id}?method=export&format={self.download_format}"
         else:
@@ -229,7 +229,8 @@ class SocrataTableMetadata:
             datetime_obj = dt.datetime.strptime(datetime_obj, "%Y-%m-%dT%H:%M:%S.%fZ")
         return datetime_obj.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    def get_latest_data_update_datetime(self) -> str:
+    @property
+    def latest_data_update_datetime(self) -> str:
         data_updated_at = self.get_table_metadata_attr(
             attr_dict=self.resource_metadata, attr_name="data_updated_at"
         )
@@ -237,7 +238,8 @@ class SocrataTableMetadata:
             return self.standardize_datetime_str_repr(datetime_obj=data_updated_at)
         return None
 
-    def get_latest_metadata_update_datetime(self) -> str:
+    @property
+    def latest_metadata_update_datetime(self) -> str:
         metadata_updated_at = self.get_table_metadata_attr(
             attr_dict=self.resource_metadata, attr_name="metadata_updated_at"
         )
@@ -265,9 +267,9 @@ class SocrataTableMetadata:
             "table_name": self.table_name,
             "download_format": self.download_format,
             "is_geospatial": self.is_geospatial,
-            "data_download_url": self.get_data_download_url(),
-            "source_data_last_updated": self.get_latest_data_update_datetime(),
-            "source_metadata_last_updated": self.get_latest_metadata_update_datetime(),
+            "data_download_url": self.data_download_url,
+            "source_data_last_updated": self.latest_data_update_datetime,
+            "source_metadata_last_updated": self.latest_metadata_update_datetime,
             "updated_data_available": None,
             "updated_metadata_available": None,
             "data_pulled_this_check": None,
@@ -286,10 +288,10 @@ class SocrataTableMetadata:
         else:
             latest_pull = check_df.loc[data_pulled_previously_mask, "time_of_check"].max()
             latest_source_data_update = typeset_zulu_tz_datetime_str(
-                datetime_str=self.get_latest_data_update_datetime()
+                datetime_str=self.latest_data_update_datetime
             )
             latest_source_metadata_update = typeset_zulu_tz_datetime_str(
-                datetime_str=self.get_latest_metadata_update_datetime()
+                datetime_str=self.latest_metadata_update_datetime
             )
             if latest_source_data_update > latest_pull:
                 self.data_freshness_check["updated_data_available"] = True

--- a/airflow/dags/cc_utils/socrata.py
+++ b/airflow/dags/cc_utils/socrata.py
@@ -131,18 +131,21 @@ class SocrataTableMetadata:
                 return any([col_dtype in socrata_geo_datatypes for col_dtype in column_datatypes])
         return False
 
+    @property
     def table_has_geo_type_view(self) -> bool:
         table_view_type = self.get_table_metadata_attr(
             attr_dict=self.resource_metadata, attr_name="lens_view_type"
         )
         return table_view_type == "geo"
 
+    @property
     def table_has_map_type_display(self) -> bool:
         table_display_type = self.get_table_metadata_attr(
             attr_dict=self.resource_metadata, attr_name="lens_display_type"
         )
         return table_display_type == "map"
 
+    @property
     def table_has_data_columns(self) -> bool:
         table_data_cols = self.get_table_metadata_attr(
             attr_dict=self.resource_metadata, attr_name="columns_name"
@@ -152,8 +155,8 @@ class SocrataTableMetadata:
     @property
     def is_geospatial(self) -> bool:
         return (
-            (not self.table_has_data_columns())
-            and (self.table_has_geo_type_view() or self.table_has_map_type_display())
+            (not self.table_has_data_columns)
+            and (self.table_has_geo_type_view or self.table_has_map_type_display)
         ) or (self.has_geospatial_feature)
 
     def get_valid_download_formats(self) -> Dict:

--- a/airflow/dags/cook_county/update_data_raw_chicago_city_boundary.py
+++ b/airflow/dags/cook_county/update_data_raw_chicago_city_boundary.py
@@ -1,0 +1,27 @@
+import datetime as dt
+import logging
+
+from airflow.decorators import dag
+
+from tasks.socrata_tasks import update_socrata_table
+from sources.tables import CHICAGO_CITY_BOUNDARY as SOCRATA_TABLE
+
+task_logger = logging.getLogger("airflow.task")
+
+
+@dag(
+    schedule=SOCRATA_TABLE.schedule,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["chicago", "cook_county", "geospatial", "data_raw", "boundary"],
+)
+def update_data_raw_chicago_city_boundary():
+    update_1 = update_socrata_table(
+        socrata_table=SOCRATA_TABLE,
+        conn_id="dwh_db_conn",
+        task_logger=task_logger,
+    )
+    update_1
+
+
+update_data_raw_chicago_city_boundary()

--- a/airflow/dags/sources/tables.py
+++ b/airflow/dags/sources/tables.py
@@ -31,8 +31,8 @@ CHICAGO_HOMICIDES_AND_SHOOTING_VICTIMIZATIONS = SocrataTable(
 CHICAGO_SHOTSPOTTER_ALERTS = SocrataTable(
     table_id="3h7q-7mdb",
     table_name="chicago_shotspotter_alerts",
-    schedule="20 7,19 * * *",
-    clean_schedule="30 7,19 * * *",
+    schedule="20 6,18 * * *",
+    clean_schedule="30 6,18 * * *",
 )
 
 CHICAGO_STREET_CENTER_LINES = SocrataTable(

--- a/airflow/dags/sources/tables.py
+++ b/airflow/dags/sources/tables.py
@@ -1,5 +1,12 @@
 from cc_utils.socrata import SocrataTable
 
+CHICAGO_CITY_BOUNDARY = SocrataTable(
+    table_id="ewy2-6yfk",
+    table_name="chicago_city_boundary",
+    schedule="0 20 10 8 *",
+    clean_schedule="10 20 10 8 *",
+)
+
 CHICAGO_CTA_TRAIN_STATIONS = SocrataTable(
     table_id="8pix-ypme",
     table_name="chicago_cta_train_stations",

--- a/airflow/dags/tasks/socrata_tasks.py
+++ b/airflow/dags/tasks/socrata_tasks.py
@@ -558,7 +558,7 @@ def dbt_staging_model_exists(task_logger: Logger, **kwargs) -> str:
         return "update_socrata_table.load_data_tg.make_dbt_staging_model"
 
 
-@task
+@task(retries=1)
 def make_dbt_staging_model(conn_id: str, task_logger: Logger, **kwargs) -> SocrataTableMetadata:
     ti = kwargs["ti"]
     socrata_metadata = ti.xcom_pull(task_ids="update_socrata_table.download_fresh_data")

--- a/airflow/dags/tasks/socrata_tasks.py
+++ b/airflow/dags/tasks/socrata_tasks.py
@@ -216,7 +216,7 @@ def download_fresh_data(task_logger: Logger, **kwargs) -> SocrataTableMetadata:
     )
     output_file_path = get_local_file_path(socrata_metadata=socrata_metadata)
     task_logger.info(f"Started downloading data at {dt.datetime.utcnow()} UTC")
-    urlretrieve(url=socrata_metadata.get_data_download_url(), filename=output_file_path)
+    urlretrieve(url=socrata_metadata.data_download_url, filename=output_file_path)
     task_logger.info(f"Finished downloading data at {dt.datetime.utcnow()} UTC")
     return socrata_metadata
 

--- a/airflow/dbt/models/staging/chicago_city_boundary.sql
+++ b/airflow/dbt/models/staging/chicago_city_boundary.sql
@@ -1,0 +1,59 @@
+{{ config(materialized='table') }}
+{% set source_cols = [
+    "name", "objectid", "shape_area", "shape_len", "geometry"
+] %}
+{% set metadata_cols = ["source_data_updated", "ingestion_check_time"] %}
+
+-- selecting all records already in the full data_raw table
+WITH records_in_data_raw_table AS (
+    SELECT *, 1 AS retention_priority
+    FROM {{ source('staging', 'chicago_city_boundary') }}
+),
+
+-- selecting all distinct records from the latest data pull (in the "temp" table)
+current_pull_with_distinct_combos_numbered AS (
+    SELECT *,
+        row_number() over(partition by
+            {% for sc in source_cols %}{{ sc }},{% endfor %}
+            {% for mc in metadata_cols %}{{ mc }}{{ "," if not loop.last }}{% endfor %}
+        ) as rn
+    FROM {{ source('staging', 'temp_chicago_city_boundary') }}
+),
+distinct_records_in_current_pull AS (
+    SELECT
+        {% for sc in source_cols %}{{ sc }},{% endfor %}
+        {% for mc in metadata_cols %}{{ mc }},{% endfor %}
+        2 AS retention_priority
+    FROM current_pull_with_distinct_combos_numbered
+    WHERE rn = 1
+),
+
+-- stacking the existing data with all distinct records from the latest pull
+data_raw_table_with_all_new_and_updated_records AS (
+    SELECT *
+    FROM records_in_data_raw_table
+        UNION ALL
+    SELECT *
+    FROM distinct_records_in_current_pull
+),
+
+-- selecting records that where source columns are distinct (keeping the earlier recovery
+--  when there are duplicates to chose from)
+data_raw_table_with_new_and_updated_records AS (
+    SELECT *,
+    row_number() over(partition by
+        {% for sc in source_cols %}{{ sc }}{{ "," if not loop.last }}{% endfor %}
+        ORDER BY retention_priority
+        ) as rn
+    FROM data_raw_table_with_all_new_and_updated_records
+),
+distinct_records_for_data_raw_table AS (
+    SELECT
+        {% for sc in source_cols %}{{ sc }},{% endfor %}
+        {% for mc in metadata_cols %}{{ mc }}{{ "," if not loop.last }}{% endfor %}
+    FROM data_raw_table_with_new_and_updated_records
+    WHERE rn = 1
+)
+
+SELECT *
+FROM distinct_records_for_data_raw_table

--- a/airflow/dbt/models/staging/sources.yml
+++ b/airflow/dbt/models/staging/sources.yml
@@ -6,6 +6,7 @@ sources:
     tags:
       - raw
     tables:
+      - name: chicago_city_boundary
       - name: chicago_cta_bus_stops
       - name: chicago_cta_train_stations
       - name: chicago_food_inspections
@@ -17,6 +18,7 @@ sources:
       - name: cook_county_parcel_locations
       - name: cook_county_parcel_sales
       - name: cook_county_parcel_value_assessments
+      - name: temp_chicago_city_boundary
       - name: temp_chicago_cta_bus_stops
       - name: temp_chicago_cta_train_stations
       - name: temp_chicago_food_inspections

--- a/airflow/tests/dags/cc_utils/data/sample_metadata_for_table_ewy2-6yfk.json
+++ b/airflow/tests/dags/cc_utils/data/sample_metadata_for_table_ewy2-6yfk.json
@@ -1,0 +1,73 @@
+{
+    "_id": "ewy2-6yfk",
+    "time_of_collection": "2022-12-27T03:35:06.025250Z",
+    "resource": {
+        "name": "Boundaries - City",
+        "id": "ewy2-6yfk",
+        "parent_fxf": [],
+        "description": "City boundary of Chicago. The data can be viewed on the Chicago Data Portal with a web browser. However, to view or use the files outside of a web browser, you will need to use compression software and special GIS software, such as ESRI ArcGIS (shapefile) or Google Earth (KML or KMZ).",
+        "attribution": "City of Chicago",
+        "attribution_link": "http://www.cityofchicago.org",
+        "contact_email": null,
+        "type": "map",
+        "updatedAt": "2017-06-30T22:02:43.000Z",
+        "createdAt": "2015-05-13T18:42:41.000Z",
+        "metadata_updated_at": "2017-06-30T22:02:43.000Z",
+        "data_updated_at": null,
+        "page_views": {
+            "page_views_last_week": 174,
+            "page_views_last_month": 1194,
+            "page_views_total": 58396,
+            "page_views_last_week_log": 7.45121111183233,
+            "page_views_last_month_log": 10.222794902868111,
+            "page_views_total_log": 15.83360663570452
+        },
+        "columns_name": [],
+        "columns_field_name": [],
+        "columns_datatype": [],
+        "columns_description": [],
+        "columns_format": [],
+        "download_count": 10451,
+        "provenance": "official",
+        "lens_view_type": "geo",
+        "lens_display_type": "map",
+        "blob_mime_type": "application/zip; charset=binary",
+        "hide_from_data_json": false,
+        "publication_date": "2015-05-13T18:42:47.000Z"
+    },
+    "classification": {
+        "categories": [],
+        "tags": [],
+        "domain_category": "Facilities & Geographic Boundaries",
+        "domain_tags": [
+            "boundaries",
+            "gis",
+            "kml",
+            "kmz",
+            "map_layer",
+            "shapefiles"
+        ],
+        "domain_metadata": [
+            {
+                "key": "Metadata_Time-Period",
+                "value": "Current as of June 2017"
+            }
+        ]
+    },
+    "metadata": {
+        "domain": "data.cityofchicago.org"
+    },
+    "permalink": "https://data.cityofchicago.org/d/ewy2-6yfk",
+    "link": "https://data.cityofchicago.org/Facilities-Geographic-Boundaries/Boundaries-City/ewy2-6yfk",
+    "preview_image_url": "https://data.cityofchicago.org/views/ewy2-6yfk/files/0c128d9e-2773-4a8c-88bb-1973ec74eaab",
+    "owner": {
+        "id": "vewm-vupz",
+        "user_type": "interactive",
+        "display_name": "Jonathan Levy"
+    },
+    "creator": {
+        "id": "vewm-vupz",
+        "user_type": "interactive",
+        "display_name": "Jonathan Levy"
+    }
+}

--- a/airflow/tests/dags/cc_utils/test_socrata.py
+++ b/airflow/tests/dags/cc_utils/test_socrata.py
@@ -11,6 +11,10 @@ import pytest
 sys.path.append("../../airflow")
 
 from dags.cc_utils import socrata
+from dags.sources.tables import (
+    COOK_COUNTY_PARCEL_SALES,
+    COOK_COUNTY_NEIGHBORHOOD_BOUNDARIES,
+)
 
 LOGGER = logging.getLogger("SocrataTesting")
 
@@ -51,9 +55,7 @@ def mock_SocrataTableMetadata(monkeysession):
 class TestCSVSocrataTableMetadata:
     @pytest.fixture(scope="class")
     def socrata_metadata(self, mock_SocrataTableMetadata):
-        socrata_table = socrata.SocrataTable(
-            table_id="wvhk-k5uv", table_name="cook_county_parcel_sales"
-        )
+        socrata_table = COOK_COUNTY_PARCEL_SALES
         mock_socrata_metadata = socrata.SocrataTableMetadata(socrata_table=socrata_table)
         yield mock_socrata_metadata
 
@@ -63,7 +65,7 @@ class TestCSVSocrataTableMetadata:
     def test_is_geospatial(self, socrata_metadata):
         LOGGER.info(f"socrata_metadata.table_name: {socrata_metadata.table_name}")
         LOGGER.info(f"socrata_metadata.data_domain: {socrata_metadata.data_domain}")
-        LOGGER.info(f"socrata_metadata.get_column_details: {socrata_metadata.get_column_details()}")
+        LOGGER.info(f"socrata_metadata.column_details: {socrata_metadata.column_details}")
         assert socrata_metadata.is_geospatial == False
 
     def test_has_a_geospatial_feature(self, socrata_metadata):
@@ -78,13 +80,31 @@ class TestCSVSocrataTableMetadata:
     def test_has_data_columns(self, socrata_metadata):
         assert socrata_metadata.table_has_data_columns() == True
 
+    def test_data_domain(self, socrata_metadata):
+        assert socrata_metadata.data_domain == "datacatalog.cookcountyil.gov"
+
+    def test_table_name(self, socrata_metadata):
+        assert socrata_metadata.table_name == "cook_county_parcel_sales"
+
+    def test_data_download_url(self, socrata_metadata):
+        assert socrata_metadata.data_download_url == (
+            "https://datacatalog.cookcountyil.gov/api/views/wvhk-k5uv/rows.csv?accessType=DOWNLOAD"
+        )
+
+    def test_download_format(self, socrata_metadata):
+        assert socrata_metadata.download_format == "csv"
+
+    def test_latest_data_update_datetime(self, socrata_metadata):
+        assert socrata_metadata.latest_data_update_datetime == "2022-12-01T06:16:57Z"
+
+    def test_latest_metadata_update_datetime(self, socrata_metadata):
+        assert socrata_metadata.latest_metadata_update_datetime == "2022-12-01T06:11:38Z"
+
 
 class TestGeojsonSocrataTableMetadata:
     @pytest.fixture(scope="class")
     def socrata_metadata(self, mock_SocrataTableMetadata):
-        socrata_table = socrata.SocrataTable(
-            table_id="wyzt-dzf8", table_name="cook_county_neighborhood_boundaries"
-        )
+        socrata_table = COOK_COUNTY_NEIGHBORHOOD_BOUNDARIES
         mock_socrata_metadata = socrata.SocrataTableMetadata(socrata_table=socrata_table)
         yield mock_socrata_metadata
 
@@ -94,7 +114,7 @@ class TestGeojsonSocrataTableMetadata:
     def test_is_geospatial(self, socrata_metadata):
         LOGGER.info(f"socrata_metadata.table_name: {socrata_metadata.table_name}")
         LOGGER.info(f"socrata_metadata.data_domain: {socrata_metadata.data_domain}")
-        LOGGER.info(f"socrata_metadata.get_column_details: {socrata_metadata.get_column_details()}")
+        LOGGER.info(f"socrata_metadata.column_details: {socrata_metadata.column_details}")
         assert socrata_metadata.is_geospatial == True
 
     def test_has_a_geospatial_feature(self, socrata_metadata):
@@ -108,3 +128,24 @@ class TestGeojsonSocrataTableMetadata:
 
     def test_has_data_columns(self, socrata_metadata):
         assert socrata_metadata.table_has_data_columns() == True
+
+    def test_data_domain(self, socrata_metadata):
+        assert socrata_metadata.data_domain == "datacatalog.cookcountyil.gov"
+
+    def test_table_name(self, socrata_metadata):
+        assert socrata_metadata.table_name == "cook_county_neighborhood_boundaries"
+
+    def test_data_download_url(self, socrata_metadata):
+        assert socrata_metadata.data_download_url == (
+            "https://datacatalog.cookcountyil.gov/api/geospatial/wyzt-dzf8?method=export"
+            + "&format=GeoJSON"
+        )
+
+    def test_download_format(self, socrata_metadata):
+        assert socrata_metadata.download_format == "GeoJSON"
+
+    def test_latest_data_update_datetime(self, socrata_metadata):
+        assert socrata_metadata.latest_data_update_datetime == "2020-05-21T15:38:11Z"
+
+    def test_latest_metadata_update_datetime(self, socrata_metadata):
+        assert socrata_metadata.latest_metadata_update_datetime == "2022-05-11T15:59:20Z"

--- a/airflow/tests/dags/cc_utils/test_socrata.py
+++ b/airflow/tests/dags/cc_utils/test_socrata.py
@@ -12,6 +12,7 @@ sys.path.append("../../airflow")
 
 from dags.cc_utils import socrata
 from dags.sources.tables import (
+    CHICAGO_CITY_BOUNDARY,
     COOK_COUNTY_PARCEL_SALES,
     COOK_COUNTY_NEIGHBORHOOD_BOUNDARIES,
 )
@@ -66,7 +67,7 @@ class TestCSVSocrataTableMetadata:
         assert socrata_metadata.is_geospatial == False
 
     def test_has_a_geospatial_feature(self, socrata_metadata):
-        assert socrata_metadata.table_has_geospatial_feature() == False
+        assert socrata_metadata.table_has_geospatial_feature == False
 
     def test_has_geo_type_view(self, socrata_metadata):
         assert socrata_metadata.table_has_geo_type_view == False
@@ -112,7 +113,7 @@ class TestGeojsonSocrataTableMetadata:
         assert socrata_metadata.is_geospatial == True
 
     def test_has_a_geospatial_feature(self, socrata_metadata):
-        assert socrata_metadata.table_has_geospatial_feature() == True
+        assert socrata_metadata.table_has_geospatial_feature == True
 
     def test_has_geo_type_view(self, socrata_metadata):
         assert socrata_metadata.table_has_geo_type_view == False
@@ -143,3 +144,50 @@ class TestGeojsonSocrataTableMetadata:
 
     def test_latest_metadata_update_datetime(self, socrata_metadata):
         assert socrata_metadata.latest_metadata_update_datetime == "2022-05-11T15:59:20Z"
+
+
+class TestGeojsonMapTypeSocrataTableMetadata:
+    @pytest.fixture(scope="class")
+    def socrata_metadata(self, mock_SocrataTableMetadata):
+        socrata_table = CHICAGO_CITY_BOUNDARY
+        mock_socrata_metadata = socrata.SocrataTableMetadata(socrata_table=socrata_table)
+        yield mock_socrata_metadata
+
+    def test_time_of_collection(self, socrata_metadata):
+        assert socrata_metadata.metadata["time_of_collection"] == "2022-12-27T03:35:06.025250Z"
+
+    def test_is_geospatial(self, socrata_metadata):
+        assert socrata_metadata.is_geospatial == True
+
+    def test_has_a_geospatial_feature(self, socrata_metadata):
+        assert socrata_metadata.table_has_geospatial_feature == False
+
+    def test_has_geo_type_view(self, socrata_metadata):
+        assert socrata_metadata.table_has_geo_type_view == True
+
+    def test_has_map_type_display(self, socrata_metadata):
+        assert socrata_metadata.table_has_map_type_display == True
+
+    def test_has_data_columns(self, socrata_metadata):
+        assert socrata_metadata.table_has_data_columns == False
+
+    def test_data_domain(self, socrata_metadata):
+        assert socrata_metadata.data_domain == "data.cityofchicago.org"
+
+    def test_table_name(self, socrata_metadata):
+        assert socrata_metadata.table_name == "chicago_city_boundary"
+
+    def test_data_download_url(self, socrata_metadata):
+        assert socrata_metadata.data_download_url == (
+            "https://data.cityofchicago.org/api/geospatial/ewy2-6yfk?method=export"
+            + "&format=GeoJSON"
+        )
+
+    def test_download_format(self, socrata_metadata):
+        assert socrata_metadata.download_format == "GeoJSON"
+
+    def test_latest_data_update_datetime(self, socrata_metadata):
+        assert socrata_metadata.latest_data_update_datetime == None
+
+    def test_latest_metadata_update_datetime(self, socrata_metadata):
+        assert socrata_metadata.latest_metadata_update_datetime == "2017-06-30T22:02:43Z"

--- a/airflow/tests/dags/cc_utils/test_socrata.py
+++ b/airflow/tests/dags/cc_utils/test_socrata.py
@@ -63,22 +63,19 @@ class TestCSVSocrataTableMetadata:
         assert socrata_metadata.metadata["time_of_collection"] == "2022-12-13T04:44:51.717900Z"
 
     def test_is_geospatial(self, socrata_metadata):
-        LOGGER.info(f"socrata_metadata.table_name: {socrata_metadata.table_name}")
-        LOGGER.info(f"socrata_metadata.data_domain: {socrata_metadata.data_domain}")
-        LOGGER.info(f"socrata_metadata.column_details: {socrata_metadata.column_details}")
         assert socrata_metadata.is_geospatial == False
 
     def test_has_a_geospatial_feature(self, socrata_metadata):
         assert socrata_metadata.table_has_geospatial_feature() == False
 
     def test_has_geo_type_view(self, socrata_metadata):
-        assert socrata_metadata.table_has_geo_type_view() == False
+        assert socrata_metadata.table_has_geo_type_view == False
 
     def test_has_map_type_display(self, socrata_metadata):
-        assert socrata_metadata.table_has_map_type_display() == False
+        assert socrata_metadata.table_has_map_type_display == False
 
     def test_has_data_columns(self, socrata_metadata):
-        assert socrata_metadata.table_has_data_columns() == True
+        assert socrata_metadata.table_has_data_columns == True
 
     def test_data_domain(self, socrata_metadata):
         assert socrata_metadata.data_domain == "datacatalog.cookcountyil.gov"
@@ -112,22 +109,19 @@ class TestGeojsonSocrataTableMetadata:
         assert socrata_metadata.metadata["time_of_collection"] == "2022-12-12T15:47:47.359187Z"
 
     def test_is_geospatial(self, socrata_metadata):
-        LOGGER.info(f"socrata_metadata.table_name: {socrata_metadata.table_name}")
-        LOGGER.info(f"socrata_metadata.data_domain: {socrata_metadata.data_domain}")
-        LOGGER.info(f"socrata_metadata.column_details: {socrata_metadata.column_details}")
         assert socrata_metadata.is_geospatial == True
 
     def test_has_a_geospatial_feature(self, socrata_metadata):
         assert socrata_metadata.table_has_geospatial_feature() == True
 
     def test_has_geo_type_view(self, socrata_metadata):
-        assert socrata_metadata.table_has_geo_type_view() == False
+        assert socrata_metadata.table_has_geo_type_view == False
 
     def test_has_map_type_display(self, socrata_metadata):
-        assert socrata_metadata.table_has_map_type_display() == False
+        assert socrata_metadata.table_has_map_type_display == False
 
     def test_has_data_columns(self, socrata_metadata):
-        assert socrata_metadata.table_has_data_columns() == True
+        assert socrata_metadata.table_has_data_columns == True
 
     def test_data_domain(self, socrata_metadata):
         assert socrata_metadata.data_domain == "datacatalog.cookcountyil.gov"


### PR DESCRIPTION
Uses property decorators to significantly simplify the `__init__` definition and adds tests to cover another kind of geospatial data set.