### PR TITLE
Updates makefile recipes and appearances of command 'docker-compose' in docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ I like to research before I buy anything, especially if it's a big-ticket item. 
 
 You can see documentation for this platform at [https://docs.analytics-data-where-house.dev/](https://docs.analytics-data-where-house.dev/). This project is still under active development and documentation will continue to evolve with the system.
 
+## System Requirements
+
+To use this system, Docker [Engine](https://docs.docker.com/engine/install/) and [Compose (v2.0.0 or higher)](https://docs.docker.com/compose/install/linux/#install-using-the-repository) are the only hard requirements. 
+
+Having python and GNU make on your host system will provide a lot of quality of life improvements (mainly a streamlined setup process and useful makefile recipes), but they're not strictly necessary.
+
+
 ## Usage
 
 After the [system is set up](https://docs.analytics-data-where-house.dev/setup/getting_started/), you can easily add a Socrata data set to the warehouse by

--- a/docs/setup/getting_started.md
+++ b/docs/setup/getting_started.md
@@ -33,7 +33,7 @@ These commands only need to be run on first startup (although you will need to r
 Run this command
 
 ```bash
-user@host:.../your_local_repo$ docker-compose up
+user@host:.../your_local_repo$ docker compose up
 ```
 
 After a brief time, system services will be up and running, and you can either [set up pgAdmin4](/setup/pgAdmin4)

--- a/docs/user_guide/validation/manually_setting_expectations.md
+++ b/docs/user_guide/validation/manually_setting_expectations.md
@@ -4,9 +4,9 @@ To manually develop your suite of expectations, get a shell in the `py-utils` co
 
 ```bash
 user@host:~/...$ make get_py_utils_shell 
-docker-compose up -d py-utils
+docker compose up -d py-utils
 cc_real_estate_dbt_airflow_ge_py-utils_1 is up-to-date
-docker-compose exec py-utils /bin/bash
+docker compose exec py-utils /bin/bash
 root@b5a3b6c2727f:/home# cd great_expectations/
 ```
 

--- a/makefile
+++ b/makefile
@@ -27,61 +27,61 @@ make_credentials: | make_venv
 		--project_dir=$(MAKEFILE_DIR_PATH)
 
 build_images:
-	docker-compose build 2>&1 | tee logs/where_house_build_logs_$(run_time).txt
+	docker compose build 2>&1 | tee logs/where_house_build_logs_$(run_time).txt
 
 init_airflow: build_images
-	docker-compose up airflow-init
+	docker compose up airflow-init
 
 initialize_system: build_images init_airflow
 
 startup:
-	docker-compose up
+	docker compose up
 
 quiet_startup:
-	docker-compose up -d
+	docker compose up -d
 
 shutdown:
-	docker-compose down
+	docker compose down
 
 restart:
-	docker-compose down;
-	docker-compose up;
+	docker compose down;
+	docker compose up;
 
 dbt_generate_docs:
-	docker-compose exec dbt_proj /bin/bash -c "dbt docs generate";
+	docker compose exec dbt_proj /bin/bash -c "dbt docs generate";
 
 serve_dbt_docs: dbt_generate_docs
-	docker-compose exec dbt_proj /bin/bash -c "dbt docs serve --port 18080";
+	docker compose exec dbt_proj /bin/bash -c "dbt docs serve --port 18080";
 
 update_dbt_packages: quiet_startup
-	docker-compose exec dbt_proj /bin/bash -c "dbt deps";
+	docker compose exec dbt_proj /bin/bash -c "dbt deps";
 
 clean_dbt:
-	docker-compose exec dbt_proj /bin/bash -c "dbt clean";
-	docker-compose exec dbt_proj /bin/bash -c "dbt deps";
+	docker compose exec dbt_proj /bin/bash -c "dbt clean";
+	docker compose exec dbt_proj /bin/bash -c "dbt deps";
 	mkdir -p airflow/dbt/target;
 
 create_warehouse_infra: quiet_startup
-	docker-compose exec airflow-scheduler /bin/bash -c \
+	docker compose exec airflow-scheduler /bin/bash -c \
 		"airflow dags trigger ensure_metadata_table_exists";
-	docker-compose exec airflow-scheduler /bin/bash -c \
+	docker compose exec airflow-scheduler /bin/bash -c \
 		"airflow dags trigger ensure_data_raw_schema_exists";
-	docker-compose exec airflow-scheduler /bin/bash -c \
+	docker compose exec airflow-scheduler /bin/bash -c \
 		"airflow dags trigger ensure_clean_schema_exists";
-	docker-compose exec airflow-scheduler /bin/bash -c \
+	docker compose exec airflow-scheduler /bin/bash -c \
 		"airflow dags trigger ensure_feature_schema_exists";
-	docker-compose exec airflow-scheduler /bin/bash -c \
+	docker compose exec airflow-scheduler /bin/bash -c \
 		"airflow dags trigger ensure_dwh_schema_exists";
-	docker-compose exec dbt_proj /bin/bash -c "dbt deps";
+	docker compose exec dbt_proj /bin/bash -c "dbt deps";
 
 build_python_img:
-	docker-compose build --no-cache py-utils 2>&1 | tee logs/python_build_logs_$(run_time).txt
+	docker compose build --no-cache py-utils 2>&1 | tee logs/python_build_logs_$(run_time).txt
 
 start_python_container:
-	docker-compose up -d py-utils
+	docker compose up -d py-utils
 
 get_py_utils_shell: start_python_container
-	docker-compose exec py-utils /bin/bash
+	docker compose exec py-utils /bin/bash
 
 run_tests: start_python_container
-	docker-compose exec py-utils /bin/bash -c "python -m pytest"
+	docker compose exec py-utils /bin/bash -c "python -m pytest"


### PR DESCRIPTION
Closes #46 

The only difference I noted so far is that `docker compose down` won't scrap the network if the py-utils container is still up (but rerunning `docker compose down` will fully shut down as soon as `docker compose stop py-utils` stops that container)  but otherwise, no discrepancies detected. (Still, I'll have to keep an eye on `compose` networking behavior).