### PR TITLE
Updated base versions of Airflow, pgAdmin, and Redis docker images.

### DIFF
--- a/Dockerfiles/airflow.Dockerfile
+++ b/Dockerfiles/airflow.Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.5.1-python3.9
+FROM apache/airflow:2.5.2-python3.9
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/Dockerfiles/pgadmin4.Dockerfile
+++ b/Dockerfiles/pgadmin4.Dockerfile
@@ -1,1 +1,1 @@
-FROM dpage/pgadmin4:6.20
+FROM dpage/pgadmin4:6.21

--- a/Dockerfiles/redis.Dockerfile
+++ b/Dockerfiles/redis.Dockerfile
@@ -1,1 +1,1 @@
-FROM redis:7.0.8
+FROM redis:7.0.9

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,7 +180,7 @@ services:
     restart: always
 
   db_admin:
-    image: adwh_pgadmin:6.20
+    image: adwh_pgadmin:6.21
     build:
       context: ./
       dockerfile: ./Dockerfiles/pgadmin4.Dockerfile
@@ -217,7 +217,7 @@ services:
 
   airflow-webserver:
     <<: *airflow-common
-    image: adwh_airflow_webserver:2.5.1
+    image: adwh_airflow_webserver:2.5.2
     command: webserver
     ports:
       - "8080:8080"
@@ -240,7 +240,7 @@ services:
 
   airflow-scheduler:
     <<: *airflow-common
-    image: adwh_airflow_scheduler:2.5.1
+    image: adwh_airflow_scheduler:2.5.2
     command: scheduler
     healthcheck:
       test:
@@ -259,7 +259,7 @@ services:
 
   airflow-triggerer:
     <<: *airflow-common
-    image: adwh_airflow_triggerer:2.5.1
+    image: adwh_airflow_triggerer:2.5.2
     command: triggerer
     healthcheck:
       test:
@@ -278,7 +278,7 @@ services:
 
   airflow-init:
     <<: *airflow-common
-    image: adwh_airflow_init:2.5.1
+    image: adwh_airflow_init:2.5.2
     entrypoint: /bin/bash
     # yamllint disable rule:line-length
     command:
@@ -305,7 +305,7 @@ services:
 
   airflow-cli:
     <<: *airflow-common
-    image: adwh_airflow_cli:2.5.1
+    image: adwh_airflow_cli:2.5.2
     profiles:
       - debug
     environment:


### PR DESCRIPTION
I've updated to Airflow 2.5.2, and then ran a few of the DAGs that caused the graphical representation to vanish. The vanishing issue appears to be solved.  Closes #57 