### PR TITLE
Standardizes dbt-running call and error catching

### DIFF
--- a/airflow/dags/cc_utils/transform.py
+++ b/airflow/dags/cc_utils/transform.py
@@ -1,0 +1,29 @@
+from logging import Logger
+import subprocess
+import re
+
+from cc_utils.utils import log_as_info
+
+
+class DbtExecutionError(Exception):
+    def __init__(self, msg):
+        super().__init__(msg)
+
+
+def run_dbt_dataset_transformations(
+    dataset_name: str, task_logger: Logger, schema: str = "data_raw", dbt_project: str = "re_dbt"
+) -> bool:
+    dbt_cmd = f"""cd /opt/airflow/dbt && \
+                  dbt --warn-error-options \
+                        '{{"include": "all", "exclude": [UnusedResourceConfigPath]}}' \
+                  run --select {dbt_project}.{schema}.{dataset_name}"""
+    log_as_info(task_logger, f"dbt run command: {dbt_cmd}")
+    subproc_output = subprocess.run(dbt_cmd, shell=True, capture_output=True, text=True)
+    raise_exception = False
+    for el in subproc_output.stdout.split("\n"):
+        log_as_info(task_logger, f"{el}")
+        if re.search("(\\d* of \\d* ERROR)", el):
+            raise DbtExecutionError(
+                msg=f"dbt model failed. Review the dbt output.\n{subproc_output.stdout}",
+            )
+    return True

--- a/airflow/dbt/models/data_raw/chicago_traffic_crashes.sql
+++ b/airflow/dbt/models/data_raw/chicago_traffic_crashes.sql
@@ -2,8 +2,8 @@
 {% set source_cols = [
     "work_zone_type", "injuries_fatal", "workers_present_i", "injuries_non_incapacitating",
     "crash_record_id", "injuries_incapacitating", "injuries_no_indication", "latitude",
-    "lighting_condition", "street_no", "injuries_unknown", "device_condition", "rd_no",
-    "crash_date", "private_property_i", "trafficway_type", "traffic_control_device", "road_defect",
+    "lighting_condition", "street_no", "injuries_unknown", "device_condition", "crash_date",
+    "private_property_i", "trafficway_type", "traffic_control_device", "road_defect",
     "damage", "crash_date_est_i", "longitude", "crash_month", "street_name", "crash_day_of_week",
     "crash_hour", "first_crash_type", "injuries_reported_not_evident", "statements_taken_i",
     "num_units", "most_severe_injury", "date_police_notified", "photos_taken_i",

--- a/airflow/dbt/models/standardized/chicago_traffic_crashes_standardized.sql
+++ b/airflow/dbt/models/standardized/chicago_traffic_crashes_standardized.sql
@@ -7,7 +7,7 @@ WITH records_with_basic_cleaning AS (
         upper(crash_record_id::text)                          AS crash_record_id,
         crash_date::timestamptz
             AT TIME ZONE 'UTC' AT TIME ZONE 'America/Chicago' AS crash_date,
-        upper(rd_no::text)                                    AS rd_no,
+        'REDACTED'                                            AS rd_no,
         street_no::int                                        AS street_no,
         upper(street_direction::char(1))                      AS street_direction,
         upper(street_name::text)                              AS street_name,


### PR DESCRIPTION
Changes:
* Pulls dbt-running command out of taskflows and into a new `cc_utils.transform` module (closes #205 )
* Retrofits the `log_as_info()` util into taskflows.
* Removes the `rd_no` column from the `data_raw` model for chicago_traffic_crashes and imputes "REDACTED" in the `standardized` model (closes #208 )