### PR TITLE
Imputes value for depracated column before first attempted access.

### DIFF
--- a/airflow/dbt/models/standardized/chicago_traffic_crashes_standardized.sql
+++ b/airflow/dbt/models/standardized/chicago_traffic_crashes_standardized.sql
@@ -7,7 +7,7 @@ WITH records_with_basic_cleaning AS (
         upper(crash_record_id::text)                          AS crash_record_id,
         crash_date::timestamptz
             AT TIME ZONE 'UTC' AT TIME ZONE 'America/Chicago' AS crash_date,
-        'REDACTED'                                            AS rd_no,
+        upper(rd_no::text)                                    AS rd_no,
         street_no::int                                        AS street_no,
         upper(street_direction::char(1))                      AS street_direction,
         upper(street_name::text)                              AS street_name,


### PR DESCRIPTION
Changes:
* Adds CTE to chicago_traffic_crashes `data_raw` model to create the column removed from the data source (`rd_no`), and modifies subsequent CTE to select from that CTE.
* Reverted the downstream change in the corresponding `standardized` model.

Closes #208 