### PR TITLE
Iss 225 dbt unit test non default coltypes

### DIFF
--- a/airflow/dbt/models/clean/schema.yml
+++ b/airflow/dbt/models/clean/schema.yml
@@ -3,7 +3,7 @@ version: 2
 models:
   - name: cook_county_parcel_sales_standardized
     config:
-      schema: clean
+      schema: standardized
     description: '{{ doc("parcels_cc_sales") }}'
     columns:
       - name: parcel_sale_id
@@ -80,7 +80,7 @@ models:
 
   - name: cook_county_parcel_locations_standardized
     config:
-      schema: clean
+      schema: standardized
     description: '{{ doc("parcels_cc_locations") }}'
     columns:
       - name: pin
@@ -183,7 +183,7 @@ models:
 
   - name: cook_county_parcel_value_assessments_standardized
     config:
-      schema: clean
+      schema: standardized
 
   - name: cook_county_parcel_value_assessments_clean
     config:
@@ -191,8 +191,8 @@ models:
 
   - name: chicago_cta_train_stations_standardized
     config:
-      schema: clean
+      schema: standardized
 
   - name: cook_county_neighborhood_boundaries_standardized
     config:
-      schema: clean
+      schema: standardized

--- a/airflow/dbt/models/clean/test_incremental_dedupe_logic.yml
+++ b/airflow/dbt/models/clean/test_incremental_dedupe_logic.yml
@@ -221,42 +221,326 @@ unit_tests:
         rows: |
           select
             1                                   as id,
+            null as case_number, null as date, null as updated_on,
             'HOMICIDE'                          as primary_type,
             'FIRST DEGREE MURDER'               as description,
+            null as iucr, null as fbi_code, null as location_description, null as domestic,
             false                               as arrest,
+            null as district, null as ward, null as beat, null as community_area, null as block,
+            null as latitude, null as longitude, null as x_coordinate, null as y_coordinate,
             ST_GeomFromText('POINT(0 0)')       as geometry,
-            '2024-11-21T22:45:31Z'::timestamptz as source_data_updated
+            '2024-11-21T22:45:31Z'::timestamptz as source_data_updated,
+            null as ingestion_check_time
           union all
           select
             1                                   as id,
+            null as case_number, null as date, null as updated_on,
             'HOMICIDE'                          as primary_type,
             'FIRST DEGREE MURDER'               as description,
+            null as iucr, null as fbi_code, null as location_description, null as domestic,
             true                                as arrest,
+            null as district, null as ward, null as beat, null as community_area, null as block,
+            null as latitude, null as longitude, null as x_coordinate, null as y_coordinate,
             ST_GeomFromText('POINT(0 0)')       as geometry,
-            '2024-12-01T15:26:57Z'::timestamptz as source_data_updated
+            '2024-12-01T15:26:57Z'::timestamptz as source_data_updated,
+            null as ingestion_check_time
           union all
           select
             2                                   as id,
+            null as case_number, null as date, null as updated_on,
             'ROBBERY'                           as primary_type,
             'ARMED: HANDGUN'                    as description,
+            null as iucr, null as fbi_code, null as location_description, null as domestic,
             false                               as arrest,
+            null as district, null as ward, null as beat, null as community_area, null as block,
+            null as latitude, null as longitude, null as x_coordinate, null as y_coordinate,
             ST_GeomFromText('POINT(0 0)')       as geometry,
-            '2024-10-24T08:13:25Z'::timestamptz as source_data_updated
+            '2024-10-24T08:13:25Z'::timestamptz as source_data_updated,
+            null as ingestion_check_time
     expect:
       format: sql
       rows: |
         select
           1                                   as id,
+          null as case_number, null as date, null as updated_on,
           'HOMICIDE'                          as primary_type,
           'FIRST DEGREE MURDER'               as description,
+          null as iucr, null as fbi_code, null as location_description, null as domestic,
           true                                as arrest,
+          null as district, null as ward, null as beat, null as community_area, null as block,
+          null as latitude, null as longitude, null as x_coordinate, null as y_coordinate,
           ST_GeomFromText('POINT(0 0)')       as geometry,
-          '2024-12-01T15:26:57Z'::timestamptz as source_data_updated
+          '2024-12-01T15:26:57Z'::timestamptz as source_data_updated,
+          null as ingestion_check_time
         union all
         select
           2                                   as id,
+          null as case_number, null as date, null as updated_on,
           'ROBBERY'                           as primary_type,
           'ARMED: HANDGUN'                    as description,
+          null as iucr, null as fbi_code, null as location_description, null as domestic,
           false                               as arrest,
+          null as district, null as ward, null as beat, null as community_area, null as block,
+          null as latitude, null as longitude, null as x_coordinate, null as y_coordinate,
           ST_GeomFromText('POINT(0 0)')       as geometry,
-          '2024-10-24T08:13:25Z'::timestamptz as source_data_updated
+          '2024-10-24T08:13:25Z'::timestamptz as source_data_updated,
+          null as ingestion_check_time
+
+  - name: chicago_crimes_clean_incremental_mode_basic_case
+    description: >
+      Scenario: a new record is added along with an existing record
+        that hasn't changed.
+    model: chicago_crimes_clean
+    overrides:
+      macros:
+        is_incremental: true
+    given:
+      - input: ref('chicago_crimes_standardized')
+        format: sql
+        rows: |
+          select
+            1                                   as id,
+            null as case_number, null as date, null as updated_on,
+            'HOMICIDE'                          as primary_type,
+            'FIRST DEGREE MURDER'               as description,
+            null as iucr, null as fbi_code, null as location_description, null as domestic,
+            false                               as arrest,
+            null as district, null as ward, null as beat, null as community_area, null as block,
+            null as latitude, null as longitude, null as x_coordinate, null as y_coordinate,
+            ST_GeomFromText('POINT(0 0)')       as geometry,
+            '2024-11-21T22:45:31Z'::timestamptz as source_data_updated,
+            null as ingestion_check_time
+          union all
+          select
+            2                                   as id,
+            null as case_number, null as date, null as updated_on,
+            'ROBBERY'                           as primary_type,
+            'ARMED: HANDGUN'                    as description,
+            null as iucr, null as fbi_code, null as location_description, null as domestic,
+            false                               as arrest,
+            null as district, null as ward, null as beat, null as community_area, null as block,
+            null as latitude, null as longitude, null as x_coordinate, null as y_coordinate,
+            ST_GeomFromText('POINT(0 0)')       as geometry,
+            '2024-10-24T08:13:25Z'::timestamptz as source_data_updated,
+            null as ingestion_check_time
+      - input: this
+        format: sql
+        rows: |
+          select
+            2                                   as id,
+            null as case_number, null as date, null as updated_on,
+            'ROBBERY'                           as primary_type,
+            'ARMED: HANDGUN'                    as description,
+            null as iucr, null as fbi_code, null as location_description, null as domestic,
+            false                               as arrest,
+            null as district, null as ward, null as beat, null as community_area, null as block,
+            null as latitude, null as longitude, null as x_coordinate, null as y_coordinate,
+            ST_GeomFromText('POINT(0 0)')       as geometry,
+            '2024-10-24T08:13:25Z'::timestamptz as source_data_updated,
+            null as ingestion_check_time
+    expect:
+      format: sql
+      rows: |
+        select
+            1                                   as id,
+            null as case_number, null as date, null as updated_on,
+            'HOMICIDE'                          as primary_type,
+            'FIRST DEGREE MURDER'               as description,
+            null as iucr, null as fbi_code, null as location_description, null as domestic,
+            false                               as arrest,
+            null as district, null as ward, null as beat, null as community_area, null as block,
+            null as latitude, null as longitude, null as x_coordinate, null as y_coordinate,
+            ST_GeomFromText('POINT(0 0)')       as geometry,
+            '2024-11-21T22:45:31Z'::timestamptz as source_data_updated,
+            null as ingestion_check_time
+
+  - name: chicago_crimes_clean_incremental_mode_update_case
+    description: >
+      Scenario: a new record is added along with an existing record
+        that has changed.
+    model: chicago_crimes_clean
+    overrides:
+      macros:
+        is_incremental: true
+    given:
+      - input: ref('chicago_crimes_standardized')
+        format: sql
+        rows: |
+          select
+            3                                   as id,
+            null as case_number, null as date, null as updated_on,
+            'BATTERY'                           as primary_type,
+            'AGGRAVATED - HANDGUN'              as description,
+            null as iucr, null as fbi_code, null as location_description, null as domestic,
+            false                               as arrest,
+            null as district, null as ward, null as beat, null as community_area, null as block,
+            null as latitude, null as longitude, null as x_coordinate, null as y_coordinate,
+            ST_GeomFromText('POINT(0 0)')       as geometry,
+            '2024-11-21T22:45:31Z'::timestamptz as source_data_updated,
+            null as ingestion_check_time
+          union all
+          select
+            3                                   as id,
+            null as case_number, null as date, null as updated_on,
+            'BATTERY'                           as primary_type,
+            'AGGRAVATED - HANDGUN'               as description,
+            null as iucr, null as fbi_code, null as location_description, null as domestic,
+            true                                as arrest,
+            null as district, null as ward, null as beat, null as community_area, null as block,
+            null as latitude, null as longitude, null as x_coordinate, null as y_coordinate,
+            ST_GeomFromText('POINT(0 0)')       as geometry,
+            '2024-12-01T15:26:57Z'::timestamptz as source_data_updated,
+            null as ingestion_check_time
+          union all
+          select
+            3                                   as id,
+            null as case_number, null as date, null as updated_on,
+            'HOMICIDE'                          as primary_type,
+            'FIRST DEGREE MURDER'               as description,
+            null as iucr, null as fbi_code, null as location_description, null as domestic,
+            true                                as arrest,
+            null as district, null as ward, null as beat, null as community_area, null as block,
+            null as latitude, null as longitude, null as x_coordinate, null as y_coordinate,
+            ST_GeomFromText('POINT(0 0)')       as geometry,
+            '2024-12-13T09:14:29Z'::timestamptz as source_data_updated,
+            null as ingestion_check_time
+          union all
+          select
+            2                                   as id,
+            null as case_number, null as date, null as updated_on,
+            'ROBBERY'                           as primary_type,
+            'ARMED: HANDGUN'                    as description,
+            null as iucr, null as fbi_code, null as location_description, null as domestic,
+            false                               as arrest,
+            null as district, null as ward, null as beat, null as community_area, null as block,
+            null as latitude, null as longitude, null as x_coordinate, null as y_coordinate,
+            ST_GeomFromText('POINT(0 0)')       as geometry,
+            '2024-10-24T08:13:25Z'::timestamptz as source_data_updated,
+            null as ingestion_check_time
+      - input: this
+        format: sql
+        rows: |
+          select
+            3                                   as id,
+            null as case_number, null as date, null as updated_on,
+            'BATTERY'                           as primary_type,
+            'AGGRAVATED - HANDGUN'               as description,
+            null as iucr, null as fbi_code, null as location_description, null as domestic,
+            true                                as arrest,
+            null as district, null as ward, null as beat, null as community_area, null as block,
+            null as latitude, null as longitude, null as x_coordinate, null as y_coordinate,
+            ST_GeomFromText('POINT(0 0)')       as geometry,
+            '2024-12-01T15:26:57Z'::timestamptz as source_data_updated,
+            null as ingestion_check_time
+          union all
+          select
+            2                                   as id,
+            null as case_number, null as date, null as updated_on,
+            'ROBBERY'                           as primary_type,
+            'ARMED: HANDGUN'                    as description,
+            null as iucr, null as fbi_code, null as location_description, null as domestic,
+            false                               as arrest,
+            null as district, null as ward, null as beat, null as community_area, null as block,
+            null as latitude, null as longitude, null as x_coordinate, null as y_coordinate,
+            ST_GeomFromText('POINT(0 0)')       as geometry,
+            '2024-10-24T08:13:25Z'::timestamptz as source_data_updated,
+            null as ingestion_check_time
+    expect:
+      format: sql
+      rows: |
+        select
+          3                                   as id,
+          null as case_number, null as date, null as updated_on,
+          'HOMICIDE'                          as primary_type,
+          'FIRST DEGREE MURDER'               as description,
+          null as iucr, null as fbi_code, null as location_description, null as domestic,
+          true                                as arrest,
+          null as district, null as ward, null as beat, null as community_area, null as block,
+          null as latitude, null as longitude, null as x_coordinate, null as y_coordinate,
+          ST_GeomFromText('POINT(0 0)')       as geometry,
+          '2024-12-13T09:14:29Z'::timestamptz as source_data_updated,
+          null as ingestion_check_time
+
+  - name: chicago_crimes_clean_incremental_mode_no_update_case
+    description: >
+      Scenario: There are new records in the latest pull but somehow they're from a
+        time before records that are already in the output model.
+        (This situation can happen when the timestamp column used to identify
+          new|updated records reflects a time that won't change, but if the column
+          reflects the time the record was updated, this situation can't happen.)
+    model: chicago_crimes_clean
+    overrides:
+      macros:
+        is_incremental: true
+    given:
+      - input: ref('chicago_crimes_standardized')
+        format: sql
+        rows: |
+          select
+            3                                   as id,
+            null as case_number, null as date, null as updated_on,
+            'BATTERY'                           as primary_type,
+            'AGGRAVATED - HANDGUN'              as description,
+            null as iucr, null as fbi_code, null as location_description, null as domestic,
+            false                               as arrest,
+            null as district, null as ward, null as beat, null as community_area, null as block,
+            null as latitude, null as longitude, null as x_coordinate, null as y_coordinate,
+            ST_GeomFromText('POINT(0 0)')       as geometry,
+            '2024-11-21T22:45:31Z'::timestamptz as source_data_updated,
+            null as ingestion_check_time
+          union all
+          select
+            3                                   as id,
+            null as case_number, null as date, null as updated_on,
+            'BATTERY'                           as primary_type,
+            'AGGRAVATED - HANDGUN'               as description,
+            null as iucr, null as fbi_code, null as location_description, null as domestic,
+            true                                as arrest,
+            null as district, null as ward, null as beat, null as community_area, null as block,
+            null as latitude, null as longitude, null as x_coordinate, null as y_coordinate,
+            ST_GeomFromText('POINT(0 0)')       as geometry,
+            '2024-12-01T15:26:57Z'::timestamptz as source_data_updated,
+            null as ingestion_check_time
+          union all
+          select
+            3                                   as id,
+            null as case_number, null as date, null as updated_on,
+            'HOMICIDE'                          as primary_type,
+            'FIRST DEGREE MURDER'               as description,
+            null as iucr, null as fbi_code, null as location_description, null as domestic,
+            true                                as arrest,
+            null as district, null as ward, null as beat, null as community_area, null as block,
+            null as latitude, null as longitude, null as x_coordinate, null as y_coordinate,
+            ST_GeomFromText('POINT(0 0)')       as geometry,
+            '2024-12-13T09:14:29Z'::timestamptz as source_data_updated,
+            null as ingestion_check_time
+          union all
+          select
+            2                                   as id,
+            null as case_number, null as date, null as updated_on,
+            'ROBBERY'                           as primary_type,
+            'ARMED: HANDGUN'                    as description,
+            null as iucr, null as fbi_code, null as location_description, null as domestic,
+            false                               as arrest,
+            null as district, null as ward, null as beat, null as community_area, null as block,
+            null as latitude, null as longitude, null as x_coordinate, null as y_coordinate,
+            ST_GeomFromText('POINT(0 0)')       as geometry,
+            '2024-10-24T08:13:25Z'::timestamptz as source_data_updated,
+            null as ingestion_check_time
+      - input: this
+        format: sql
+        rows: |
+          select
+            3                                   as id,
+            null as case_number, null as date, null as updated_on,
+            'HOMICIDE'                          as primary_type,
+            'FIRST DEGREE MURDER'               as description,
+            null as iucr, null as fbi_code, null as location_description, null as domestic,
+            true                                as arrest,
+            null as district, null as ward, null as beat, null as community_area, null as block,
+            null as latitude, null as longitude, null as x_coordinate, null as y_coordinate,
+            ST_GeomFromText('POINT(0 0)')       as geometry,
+            '2024-12-13T09:14:29Z'::timestamptz as source_data_updated,
+            null as ingestion_check_time
+    expect:
+      rows: []

--- a/airflow/dbt/models/clean/test_incremental_dedupe_logic.yml
+++ b/airflow/dbt/models/clean/test_incremental_dedupe_logic.yml
@@ -217,35 +217,46 @@ unit_tests:
         is_incremental: false
     given:
       - input: ref('chicago_crimes_standardized')
-        format: dict
-        rows:
-          - id: '00001'
-            primary_type: 'HOMICIDE'
-            description: 'FIRST DEGREE MURDER'
-            arrest: false
-            source_data_updated: '2024-11-21T22:45:31Z'
-
-          - id: '00001'
-            primary_type: 'HOMICIDE'
-            description: 'FIRST DEGREE MURDER'
-            arrest: true
-            source_data_updated: '2024-12-01T15:26:57Z'
-
-          - id: '00002'
-            primary_type: 'ROBBERY'
-            description: 'ARMED: HANDGUN'
-            arrest: false
-            source_data_updated: '2024-10-24T08:13:25Z'
+        format: sql
+        rows: |
+          select
+            1                                   as id,
+            'HOMICIDE'                          as primary_type,
+            'FIRST DEGREE MURDER'               as description,
+            false                               as arrest,
+            ST_GeomFromText('POINT(0 0)')       as geometry,
+            '2024-11-21T22:45:31Z'::timestamptz as source_data_updated
+          union all
+          select
+            1                                   as id,
+            'HOMICIDE'                          as primary_type,
+            'FIRST DEGREE MURDER'               as description,
+            true                                as arrest,
+            ST_GeomFromText('POINT(0 0)')       as geometry,
+            '2024-12-01T15:26:57Z'::timestamptz as source_data_updated
+          union all
+          select
+            2                                   as id,
+            'ROBBERY'                           as primary_type,
+            'ARMED: HANDGUN'                    as description,
+            false                               as arrest,
+            ST_GeomFromText('POINT(0 0)')       as geometry,
+            '2024-10-24T08:13:25Z'::timestamptz as source_data_updated
     expect:
-      rows:
-        - id: '00001'
-          primary_type: 'HOMICIDE'
-          description: 'FIRST DEGREE MURDER'
-          arrest: true
-          source_data_updated: '2024-12-01T15:26:57Z'
-
-        - id: '00002'
-          primary_type: 'ROBBERY'
-          description: 'ARMED: HANDGUN'
-          arrest: false
-          source_data_updated: '2024-10-24T08:13:25Z'
+      format: sql
+      rows: |
+        select
+          1                                   as id,
+          'HOMICIDE'                          as primary_type,
+          'FIRST DEGREE MURDER'               as description,
+          true                                as arrest,
+          ST_GeomFromText('POINT(0 0)')       as geometry,
+          '2024-12-01T15:26:57Z'::timestamptz as source_data_updated
+        union all
+        select
+          2                                   as id,
+          'ROBBERY'                           as primary_type,
+          'ARMED: HANDGUN'                    as description,
+          false                               as arrest,
+          ST_GeomFromText('POINT(0 0)')       as geometry,
+          '2024-10-24T08:13:25Z'::timestamptz as source_data_updated

--- a/airflow/dbt/models/clean/test_incremental_dedupe_logic.yml
+++ b/airflow/dbt/models/clean/test_incremental_dedupe_logic.yml
@@ -205,3 +205,47 @@ unit_tests:
             source_data_updated: '2024-12-04T08:13:25Z'
     expect:
       rows: []
+
+  - name: chicago_crimes_clean_initial_full_refresh
+    description: >
+      Scenario: Clean-stage deduplication.
+        Multiple distinct versions of records were ingested to data_raw and only the
+        latest version of each record should be retained.
+    model: chicago_crimes_clean
+    overrides:
+      macros:
+        is_incremental: false
+    given:
+      - input: ref('chicago_crimes_standardized')
+        format: dict
+        rows:
+          - id: '00001'
+            primary_type: 'HOMICIDE'
+            description: 'FIRST DEGREE MURDER'
+            arrest: false
+            source_data_updated: '2024-11-21T22:45:31Z'
+
+          - id: '00001'
+            primary_type: 'HOMICIDE'
+            description: 'FIRST DEGREE MURDER'
+            arrest: true
+            source_data_updated: '2024-12-01T15:26:57Z'
+
+          - id: '00002'
+            primary_type: 'ROBBERY'
+            description: 'ARMED: HANDGUN'
+            arrest: false
+            source_data_updated: '2024-10-24T08:13:25Z'
+    expect:
+      rows:
+        - id: '00001'
+          primary_type: 'HOMICIDE'
+          description: 'FIRST DEGREE MURDER'
+          arrest: true
+          source_data_updated: '2024-12-01T15:26:57Z'
+
+        - id: '00002'
+          primary_type: 'ROBBERY'
+          description: 'ARMED: HANDGUN'
+          arrest: false
+          source_data_updated: '2024-10-24T08:13:25Z'

--- a/airflow/dbt/models/data_raw/schema.yml
+++ b/airflow/dbt/models/data_raw/schema.yml
@@ -13,11 +13,6 @@ models:
   - name: cook_county_parcel_value_assessments
     description: '{{ doc("parcels_cc_value_assessments") }}'
     columns:
-      - name: assessment_id
-        description: Uniquely defines the assessments for a parcel for one tax-year.
-        data_tests:
-          # - unique
-          - not_null
       - name: pin
       - name: tax_year
       - name: class
@@ -45,11 +40,6 @@ models:
   - name: cook_county_neighborhood_boundaries
     description: '{{ doc("parcels_cc_nbhd_boundaries") }}'
     columns:
-      - name: nbhd_id
-        description: Uniquely identifies a neighborhood boundary.
-        data_tests:
-          - unique
-          - not_null
       - name: triad_name
         description: >
           Reassessment of property in Cook County is done within a triennial cycle, meaning it occurs every three years. The Cook County Assessor's Office alternates reassessments between triads: the north and west suburbs, the south and west suburbs and the City of Chicago.

--- a/airflow/dbt/models/data_raw/test_distinct_record_retention_logic.yml
+++ b/airflow/dbt/models/data_raw/test_distinct_record_retention_logic.yml
@@ -7,62 +7,128 @@ unit_tests:
     model: chicago_crimes
     given:
       - input: source('data_raw', 'temp_chicago_crimes')
-        rows:
-          - id: '00001'
-            date: '2023-07-28 02:31:00'
-            iucr: '0110'
-            primary_type: 'HOMICIDE'
-            description: 'FIRST DEGREE MURDER'
-            source_data_updated: '2023-07-05T19:32:45Z'
-            ingestion_check_time: '2023-07-06T04:10:04.411071Z'
-
-          - id: '00002'
-            date: '2012-08-05 22:00:00'
-            iucr: '031A'
-            primary_type: 'ROBBERY'
-            description: 'ARMED: HANDGUN'
-            source_data_updated: '2023-07-05T19:32:45Z'
-            ingestion_check_time: '2023-07-06T04:10:04.411071Z'
+        format: sql
+        rows: |
+          select
+            null as location_state, null as location_zip, null as x_coordinate, null as domestic,
+            null as latitude, null as updated_on,
+            'FIRST DEGREE MURDER'         as description,
+            null as location_address, null as arrest, null as location_city, null as year,
+            null as longitude, null as block, null as fbi_code, null as ward,
+            '00001'                       as id,
+            '2023-07-28 02:31:00'         as date,
+            null as beat, null as y_coordinate, null as community_area,
+            null as location_description, null as district,
+            '0110'                        as iucr,
+            null as case_number,
+            'HOMICIDE'                    as primary_type,
+            ST_GeomFromText('POINT(0 0)') as geometry,
+            '2023-07-05T19:32:45Z'        as source_data_updated,
+            '2023-07-06T04:10:04.411071Z' as ingestion_check_time
+          union all
+          select
+            null as location_state, null as location_zip, null as x_coordinate, null as domestic,
+            null as latitude, null as updated_on,
+            'ARMED: HANDGUN'              as description,
+            null as location_address, null as arrest, null as location_city, null as year,
+            null as longitude, null as block, null as fbi_code, null as ward,
+            '00002'                       as id,
+            '2012-08-05 22:00:00'         as date,
+            null as beat, null as y_coordinate, null as community_area,
+            null as location_description, null as district,
+            '031A'                        as iucr,
+            null as case_number,
+            'ROBBERY'                     as primary_type,
+            ST_GeomFromText('POINT(0 0)') as geometry,
+            '2023-07-05T19:32:45Z'        as source_data_updated,
+            '2023-07-06T04:10:04.411071Z' as ingestion_check_time
 
       - input: source('data_raw', 'chicago_crimes')
-        rows:
-          - id: '00001'
-            date: '2023-07-28 02:31:00'
-            iucr: '041A'
-            primary_type: 'BATTERY'
-            description: 'AGGRAVATED: HANDGUN'
-            source_data_updated: '2023-06-05T19:37:04Z'
-            ingestion_check_time: '2023-06-06T04:17:32.411071Z'
-
-          - id: '00002'
-            date: '2012-08-05 22:00:00'
-            iucr: '031A'
-            primary_type: 'ROBBERY'
-            description: 'ARMED: HANDGUN'
-            source_data_updated: '2023-02-17T15:09:14Z'
-            ingestion_check_time: '2023-02-18T00:22:43.172531Z'
+        format: sql
+        rows: |
+          select
+            null as location_state, null as location_zip, null as x_coordinate, null as domestic,
+            null as latitude, null as updated_on,
+            'AGGRAVATED: HANDGUN'         as description,
+            null as location_address, null as arrest, null as location_city, null as year,
+            null as longitude, null as block, null as fbi_code, null as ward,
+            '00001'                       as id,
+            '2023-07-28 02:31:00'         as date,
+            null as beat, null as y_coordinate, null as community_area,
+            null as location_description, null as district,
+            '041A'                        as iucr,
+            null as case_number,
+            'BATTERY'                     as primary_type,
+            ST_GeomFromText('POINT(0 0)') as geometry,
+            '2023-06-05T19:37:04Z'        as source_data_updated,
+            '2023-06-06T04:17:32.411071Z' as ingestion_check_time
+          union all
+          select
+            null as location_state, null as location_zip, null as x_coordinate, null as domestic,
+            null as latitude, null as updated_on,
+            'ARMED: HANDGUN'              as description,
+            null as location_address, null as arrest, null as location_city, null as year,
+            null as longitude, null as block, null as fbi_code, null as ward,
+            '00002'                       as id,
+            '2012-08-05 22:00:00'         as date,
+            null as beat, null as y_coordinate, null as community_area,
+            null as location_description, null as district,
+            '031A'                        as iucr,
+            null as case_number,
+            'ROBBERY'                     as primary_type,
+            ST_GeomFromText('POINT(0 0)') as geometry,
+            '2023-02-17T15:09:14Z'        as source_data_updated,
+            '2023-02-18T00:22:43.172531Z' as ingestion_check_time
     expect:
-      rows:
-        - id: '00001'
-          date: '2023-07-28 02:31:00'
-          iucr: '041A'
-          primary_type: 'BATTERN'
-          description: 'AGGRAVATED: HANDGUN'
-          source_data_updated: '2023-06-05T19:37:04Z'
-          ingestion_check_time: '2023-06-06T04:17:32.411071Z'
-
-        - id: '00001'
-          date: '2023-07-28 02:31:00'
-          iucr: '0110'
-          primary_type: 'HOMICIDE'
-          description: 'FIRST DEGREE MURDER'
-          source_data_updated: '2023-07-05T19:32:45Z'
-          ingestion_check_time: '2023-07-06T04:10:04.411071Z'
-
-        - id: '00002'
-          date: '2012-08-05 22:00:00'
-          iucr: '031A'
-          primary_type: 'ROBBERY'
-          description: 'ARMED: HANDGUN'
-          source_data_updated: '2023-02-17T15:09:14Z'
-          ingestion_check_time: '2023-02-18T00:22:43.172531Z'
+      format: sql
+      rows: |
+        select
+          null as location_state, null as location_zip, null as x_coordinate, null as domestic,
+          null as latitude, null as updated_on,
+          'AGGRAVATED: HANDGUN'         as description,
+          null as location_address, null as arrest, null as location_city, null as year,
+          null as longitude, null as block, null as fbi_code, null as ward,
+          '00001'                       as id,
+          '2023-07-28 02:31:00'         as date,
+          null as beat, null as y_coordinate, null as community_area,
+          null as location_description, null as district,
+          '041A'                        as iucr,
+          null as case_number,
+          'BATTERY'                     as primary_type,
+          ST_GeomFromText('POINT(0 0)') as geometry,
+          '2023-06-05T19:37:04Z'        as source_data_updated,
+          '2023-06-06T04:17:32.411071Z' as ingestion_check_time
+        union all
+        select
+          null as location_state, null as location_zip, null as x_coordinate, null as domestic,
+          null as latitude, null as updated_on,
+          'FIRST DEGREE MURDER'         as description,
+          null as location_address, null as arrest, null as location_city, null as year,
+          null as longitude, null as block, null as fbi_code, null as ward,
+          '00001'                       as id,
+          '2023-07-28 02:31:00'         as date,
+          null as beat, null as y_coordinate, null as community_area,
+          null as location_description, null as district,
+          '0110'                        as iucr,
+          null as case_number,
+          'HOMICIDE'                    as primary_type,
+          ST_GeomFromText('POINT(0 0)') as geometry,
+          '2023-07-05T19:32:45Z'        as source_data_updated,
+          '2023-07-06T04:10:04.411071Z' as ingestion_check_time
+        union all
+        select
+          null as location_state, null as location_zip, null as x_coordinate, null as domestic,
+          null as latitude, null as updated_on,
+          'ARMED: HANDGUN'              as description,
+          null as location_address, null as arrest, null as location_city, null as year,
+          null as longitude, null as block, null as fbi_code, null as ward,
+          '00002'                       as id,
+          '2012-08-05 22:00:00'         as date,
+          null as beat, null as y_coordinate, null as community_area,
+          null as location_description, null as district,
+          '031A'                        as iucr,
+          null as case_number,
+          'ROBBERY'                     as primary_type,
+          ST_GeomFromText('POINT(0 0)') as geometry,
+          '2023-02-17T15:09:14Z'        as source_data_updated,
+          '2023-02-18T00:22:43.172531Z' as ingestion_check_time


### PR DESCRIPTION
Changes:
* Updated `data_raw`-stage `unit_test` to A) mock up data in the sql format, and thus B) actually run without error. Closes #225 
* Adds `clean`-stage dedupe-logic `unit_test`s against a model with a geospatial column to test the dedupe logic macro against similar models.
* Removes two columns that don't exist in `data_raw` models from the `data_raw/schema.yml`
* Updates the `clean/schema.yml` to reflect the (ancient) refactoring (from [here](https://github.com/MattTriano/analytics_data_where_house/tree/6e850351567971ae2b55a0ffa389d27daeb84011/airflow/dbt/models/intermediate)) that separated the `_standardized` and `_clean` stage models into separate schemas.


Regarding the unit_tests, I'm not too happy with this fix, the tests are much harder to read and quickly identify the differences that are being tested. Hopefully a more elegant solution emerges, but this workaround gets `unit_test`s against geospatial models to actually work, which is good enough for now.